### PR TITLE
Rename check_including_global_phase=Ture -> up_to_global_phase=False #59

### DIFF
--- a/quantestpy/circuit.py
+++ b/quantestpy/circuit.py
@@ -23,7 +23,7 @@ def assert_equal_to_operator(
         test_circuit: TestCircuit = None,
         from_right_to_left_for_qubit_ids: bool = False,
         number_of_decimal_places: int = 5,
-        check_including_global_phase: bool = True,
+        up_to_global_phase: bool = False,
         msg=None) -> None:
 
     if qasm is None and qiskit_circuit is None and test_circuit is None:
@@ -54,7 +54,7 @@ def assert_equal_to_operator(
         operator_from_test_circuit,
         operator_,
         number_of_decimal_places,
-        check_including_global_phase,
+        up_to_global_phase,
         msg)
 
 

--- a/quantestpy/operator.py
+++ b/quantestpy/operator.py
@@ -35,7 +35,7 @@ def assert_equal(
         operator_a: Union[np.ndarray, np.matrix],
         operator_b: Union[np.ndarray, np.matrix],
         number_of_decimal_places: int = 5,
-        check_including_global_phase: bool = True,
+        up_to_global_phase: bool = False,
         msg=None) -> None:
 
     a = operator_a
@@ -60,4 +60,4 @@ def assert_equal(
 
     # Note: error message dhould
     state_vector.assert_equal(a, b, number_of_decimal_places,
-                              check_including_global_phase, msg)
+                              up_to_global_phase, msg)

--- a/quantestpy/state_vector.py
+++ b/quantestpy/state_vector.py
@@ -41,7 +41,7 @@ def assert_equal(
         state_vector_a: Union[np.ndarray, list],
         state_vector_b: Union[np.ndarray, list],
         number_of_decimal_places: int = 5,
-        check_including_global_phase: bool = True,
+        up_to_global_phase: bool = False,
         msg=None):
 
     a = state_vector_a
@@ -72,7 +72,7 @@ def assert_equal(
         )
 
     # remove global phase
-    if not check_including_global_phase:
+    if up_to_global_phase:
 
         abs_a = np.abs(a)
         max_value_abs_a = np.max(abs_a)

--- a/test/test_state_vector_assert_equal.py
+++ b/test/test_state_vector_assert_equal.py
@@ -27,7 +27,7 @@ class TestStateVectorAssertEqual(unittest.TestCase):
             state_vector.assert_equal(
                 vec_a,
                 vec_b,
-                check_including_global_phase=False
+                up_to_global_phase=True
             )
         )
 
@@ -41,11 +41,11 @@ class TestStateVectorAssertEqual(unittest.TestCase):
             state_vector.assert_equal(
                 vec_a,
                 vec_b,
-                check_including_global_phase=False
+                up_to_global_phase=True
             )
         )
 
-    def test_check_including_global_phase_is_true(self,):
+    def test_up_to_global_phase_is_false(self,):
         vec_a = np.array([1, 1j, -1j, -0.999123j]) / 2.
         vec_b = np.array([1, 1j, -1j, -0.999j]) / 2.
 
@@ -53,7 +53,6 @@ class TestStateVectorAssertEqual(unittest.TestCase):
             state_vector.assert_equal(
                 vec_a,
                 vec_b,
-                check_including_global_phase=True,
                 number_of_decimal_places=3
             )
         )
@@ -62,11 +61,10 @@ class TestStateVectorAssertEqual(unittest.TestCase):
             state_vector.assert_equal(
                 vec_a,
                 vec_b,
-                check_including_global_phase=True,
                 number_of_decimal_places=4
             )
 
-    def test_check_including_global_phase_is_true_error_on_purpose(self,):
+    def test_up_to_global_phase_is_false_error_on_purpose(self,):
         vec_a = np.array([0.1+0.04j, 0.01, 0.5+0.007j, 0.001+0.1j]) \
             / 0.5201442107723587
         vec_b = np.array([0.1+0.04j, 0.01, 0.5+0.007j, 0.001+0.1j]) \
@@ -75,6 +73,5 @@ class TestStateVectorAssertEqual(unittest.TestCase):
         with self.assertRaises(QuantestPyAssertionError):
             state_vector.assert_equal(
                 vec_a,
-                vec_b,
-                check_including_global_phase=True
+                vec_b
             )


### PR DESCRIPTION
**Items**
- Simply I replaced `check_including_global_phase` with `up_to_global_phase`. The default for `up_to_global_phase` is `False`, namely removing global phases is not the default behavior.
- I modified a test file so that it passes.  