### PR TITLE
Error message with significant digits up to 15 #101

### DIFF
--- a/quantestpy/state_vector.py
+++ b/quantestpy/state_vector.py
@@ -92,11 +92,11 @@ def assert_equal(
         a, b = _remove_global_phase_from_two_vectors(a, b)
 
     # round
-    a = np.round(a, decimals=number_of_decimal_places)
-    b = np.round(b, decimals=number_of_decimal_places)
+    a_rounded = np.round(a, decimals=number_of_decimal_places)
+    b_rounded = np.round(b, decimals=number_of_decimal_places)
 
     # assert equal
-    equals = a == b
+    equals = a_rounded == b_rounded
     if np.all(equals):
         return
 
@@ -105,8 +105,8 @@ def assert_equal(
         if not equal:
             error_msgs.append((
                 f"\n{i}th element:\n"
-                f"a: {a[i]}\n"
-                f"b: {b[i]}"
+                + "a: {:.15g}\n".format(a[i])
+                + "b: {:.15g}\n".format(b[i])
             ))
     error_msg = "".join(error_msgs)
     msg = ut_test_case._formatMessage(msg, error_msg)


### PR DESCRIPTION
When I was making demos, I realized that numbers in the assertion error message is not user friendly.
By this update, the output numbers have more digits, which might look too much information.  
However, users can read a value of `number_of_decimal_places` for passing the assert_method.

The output of 
```py
circuit.assert_equal(
    qiskit_circuit_a=qc_approx,
    qiskit_circuit_b=qc_ideal,
    number_of_decimal_places=5
)
```
is:

Before:
```py
QuantestPyAssertionError: 
0th element:
a: (1e-05-0j)
b: (0.99992-0.01227j)
1th element:
a: (0.01228-0.99992j)
b: 0j
2th element:
a: (-0.69837+0.71574j)
b: 0j
3th element:
a: (-0-1e-05j)
b: (0.99992+0.01227j)
```
After:
```py
QuantestPyAssertionError: 
0th element:
a: 5.95376407192647e-06-1.83144834815201e-06j
b: 0.999924701839145-0.0122715382857199j

1th element:
a: 0.0122791987315662-0.999924607777856j
b: 0+0j

2th element:
a: -0.698370766144391+0.715736175525652j
b: 0+0j

3th element:
a: -2.91491740271962e-06-5.5049764955835e-06j
b: 0.999924701839145+0.0122715382857199j
```
which is more readable and has more information.

Note that #15 comes from the limitation of python's float; see e.g. [ref](https://atmarkit.itmedia.co.jp/ait/articles/1904/09/news016.html#:~:text=%E4%BB%8A%E8%A6%8B%E3%81%9F%E3%82%88%E3%81%86%E3%81%AB%E3%80%81%E6%B5%AE%E5%8B%95,%E3%82%88%E3%81%86%E3%81%AB%E3%81%AA%E3%81%A3%E3%81%A6%E3%81%84%E3%82%8B%E3%80%82)