### PR TITLE
Stop calling state_vector.assert_equal() inside operator.assert_equal()

### DIFF
--- a/quantestpy/operator.py
+++ b/quantestpy/operator.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from typing import Union
 from quantestpy.exceptions import QuantestPyError, QuantestPyAssertionError
-from quantestpy import state_vector
+from quantestpy.state_vector import _remove_global_phase_from_two_vectors
 
 ut_test_case = unittest.TestCase()
 
@@ -64,7 +64,7 @@ def assert_equal(
         b = np.ravel(b)
 
         # rm. global phase
-        a, b = state_vector._remove_global_phase_from_two_vectors(a, b)
+        a, b = _remove_global_phase_from_two_vectors(a, b)
 
         # cvt. back to matrix
         a = np.reshape(a, newshape=a_shape)

--- a/quantestpy/operator.py
+++ b/quantestpy/operator.py
@@ -55,9 +55,32 @@ def assert_equal(
             "The shapes of the operators must be the same."
         )
 
-    # cvt. to vector
-    a = np.ravel(a)
-    b = np.ravel(b)
+    # remove global phase
+    if up_to_global_phase:
+        a_shape = a.shape
 
-    # Note: error message dhould
-    state_vector.assert_equal(a, b, rtol, atol, up_to_global_phase, msg)
+        # cvt. to vector
+        a = np.ravel(a)
+        b = np.ravel(b)
+
+        # rm. global phase
+        a, b = state_vector._remove_global_phase_from_two_vectors(a, b)
+
+        # cvt. back to matrix
+        a = np.reshape(a, newshape=a_shape)
+        b = np.reshape(b, newshape=a_shape)
+
+    # assert equal
+    try:
+        np.testing.assert_allclose(
+            actual=a,
+            desired=b,
+            rtol=rtol,
+            atol=atol,
+            err_msg=f"Up to global phase: {up_to_global_phase}"
+        )
+
+    except AssertionError as e:
+        error_msg = e.args[0]
+        msg = ut_test_case._formatMessage(msg, error_msg)
+        raise QuantestPyAssertionError(msg)

--- a/test/test_operator_assert_equal.py
+++ b/test/test_operator_assert_equal.py
@@ -1,0 +1,64 @@
+import unittest
+import numpy as np
+
+from quantestpy import operator
+from quantestpy.exceptions import QuantestPyAssertionError
+
+
+class TestOperatorAssertEqual(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.test_operator_assert_equal
+    ..
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.007s
+
+    OK
+    $
+    """
+
+    def test_reqular(self,):
+        op_a = np.array(
+            [[1., 0., 1., 0.],
+             [0., 1., 0., 1.],
+             [1., 0., -1., 0.],
+             [0., 1., 0., -1.]]
+        ) / np.sqrt(2.)
+
+        op_b = np.array(
+            [[1., 0., 1., 0.],
+             [0., 1., 0., 1.],
+             [1., 0., -1., 0.],
+             [0., 1., 0., -1.]]
+        ) / np.sqrt(2.) * np.exp(0.4j)
+
+        self.assertIsNone(
+            operator.assert_equal(
+                op_a,
+                op_b,
+                up_to_global_phase=True
+            )
+        )
+
+    def test_fail_if_not_tp_to_global_phase(self,):
+        op_a = np.array(
+            [[1., 0., 1., 0.],
+             [0., 1., 0., 1j],
+             [1., 0., -1., 0.],
+             [0., 1j, 0., -1.]]
+        ) / np.sqrt(2.)
+
+        op_b = np.array(
+            [[1., 0., 1., 0.],
+             [0., 1., 0., 1j],
+             [1., 0., -1., 0.],
+             [0., 1j, 0., -1.]]
+        ) / np.sqrt(2.) * np.exp(0.7j)
+
+        with self.assertRaises(QuantestPyAssertionError):
+            operator.assert_equal(
+                op_a,
+                op_b
+            )


### PR DESCRIPTION
Before：
```py
QuantestPyAssertionError: 
Not equal to tolerance rtol=0, atol=1e-08
Up to global phase: False
Mismatched elements: 4 / 4 (100%)
Max absolute difference: 1.
Max relative difference: 1.
 x: array([-1., -0., -0., -1.])  # <- vector form :(
 y: array([0, 1, 1, 0])
```

After:
```py
QuantestPyAssertionError: 
Not equal to tolerance rtol=0, atol=1e-08
Up to global phase: False
Mismatched elements: 4 / 4 (100%)
Max absolute difference: 1.
Max relative difference: 1.
 x: array([[-1., -0.],
       [-0., -1.]])  # <- matrix form :)
 y: array([[0, 1],
       [1, 0]])
```

This is a small modification. But, I believe that it becomes easier to see the difference(s), when the numbers of elements is huge. 