### PR TITLE
Unify qiskit_circuit, qasm and test_circuit at the circuit assert methods

### DIFF
--- a/quantestpy/circuit.py
+++ b/quantestpy/circuit.py
@@ -123,31 +123,28 @@ def assert_is_zero(circuit: Union[TestCircuit, str],
         raise QuantestPyAssertionError(msg)
 
 
-def assert_ancilla_is_zero(ancilla_qubits: list,
-                           qasm: str = None,
-                           qiskit_circuit=None,
-                           test_circuit: TestCircuit = None,
+def assert_ancilla_is_zero(circuit: Union[TestCircuit, str],
+                           ancilla_qubits: list,
                            atol: float = 1e-8,
                            msg=None) -> None:
 
-    if qasm is None and qiskit_circuit is None and test_circuit is None:
+    # test_circuit
+    if isinstance(circuit, TestCircuit):
+        test_circuit = circuit
+
+    # qasm
+    elif isinstance(circuit, str):
+        test_circuit = _cvt_openqasm_to_test_circuit(circuit)
+
+    # qiskit.QuantumCircuit()
+    elif _is_instance_of_qiskit_quantumcircuit(circuit):
+        test_circuit = _cvt_qiskit_to_test_circuit(circuit)
+
+    else:
         raise QuantestPyError(
-            "Missing qasm or qiskit_circuit or test circuit."
+            "Input circuit must be one of the following: "
+            "qasm, qiskit.QuantumCircuit and TestCircuit."
         )
-
-    if (qasm is not None and qiskit_circuit is not None) \
-            or (qasm is not None and test_circuit is not None) \
-            or (qiskit_circuit is not None and test_circuit is not None):
-        raise QuantestPyError(
-            "You need to choose one parameter of Qasm, \
-                qiskit_circuit and test circuit."
-        )
-
-    if qasm is not None:
-        test_circuit = _cvt_openqasm_to_test_circuit(qasm)
-
-    if qiskit_circuit is not None:
-        test_circuit = _cvt_qiskit_to_test_circuit(qiskit_circuit)
 
     if not isinstance(ancilla_qubits, list):
         raise QuantestPyError(

--- a/quantestpy/circuit.py
+++ b/quantestpy/circuit.py
@@ -57,33 +57,28 @@ def assert_equal_to_operator(
         msg)
 
 
-def assert_is_zero(qasm: str = None,
-                   qiskit_circuit=None,
-                   test_circuit: TestCircuit = None,
+def assert_is_zero(circuit: Union[TestCircuit, str],
                    qubits: list = None,
                    atol: float = 1e-8,
                    msg=None) -> None:
 
-    # Memo220805JN: the following input checker may be common for the other
-    # functions in this module, thus can be one function.
-    if qasm is None and qiskit_circuit is None and test_circuit is None:
+    # test_circuit
+    if isinstance(circuit, TestCircuit):
+        test_circuit = circuit
+
+    # qasm
+    elif isinstance(circuit, str):
+        test_circuit = _cvt_openqasm_to_test_circuit(circuit)
+
+    # qiskit.QuantumCircuit()
+    elif _is_instance_of_qiskit_quantumcircuit(circuit):
+        test_circuit = _cvt_qiskit_to_test_circuit(circuit)
+
+    else:
         raise QuantestPyError(
-            "Missing qasm or qiskit_circuit or test circuit."
+            "Input circuit must be one of the following: "
+            "qasm, qiskit.QuantumCircuit and TestCircuit."
         )
-
-    if (qasm is not None and qiskit_circuit is not None) \
-            or (qasm is not None and test_circuit is not None) \
-            or (qiskit_circuit is not None and test_circuit is not None):
-        raise QuantestPyError(
-            "You need to choose one parameter of Qasm, \
-                qiskit_circuit and test circuit."
-        )
-
-    if qasm is not None:
-        test_circuit = _cvt_openqasm_to_test_circuit(qasm)
-
-    if qiskit_circuit is not None:
-        test_circuit = _cvt_qiskit_to_test_circuit(qiskit_circuit)
 
     if not isinstance(qubits, list) and qubits is not None:
         raise QuantestPyError(
@@ -187,7 +182,7 @@ def assert_ancilla_is_zero(ancilla_qubits: list,
 
         # assertion using assert_is_zero
         try:
-            assert_is_zero(test_circuit=test_circuit,
+            assert_is_zero(circuit=test_circuit,
                            qubits=ancilla_qubits,
                            atol=atol)
 

--- a/quantestpy/circuit.py
+++ b/quantestpy/circuit.py
@@ -253,12 +253,8 @@ def _get_matrix_norm(
 
 
 def assert_equal(
-        qasm_a: Union[str, None] = None,
-        qiskit_circuit_a=None,
-        test_circuit_a: Union[TestCircuit, None] = None,
-        qasm_b: Union[str, None] = None,
-        qiskit_circuit_b=None,
-        test_circuit_b: Union[TestCircuit, None] = None,
+        circuit_a: Union[TestCircuit, str],
+        circuit_b: Union[TestCircuit, str],
         rtol: float = 0.,
         atol: float = 1e-8,
         up_to_global_phase: bool = False,
@@ -266,75 +262,41 @@ def assert_equal(
         msg: Union[str, None] = None):
 
     # Check inputs for circuit A
-    if qasm_a is None and qiskit_circuit_a is None and test_circuit_a is None:
-        raise QuantestPyError(
-            "Missing information for circuit A. "
-            "One of the following must be given: "
-            "qasm_a, qiskit_circuit_a and test_circuit_a."
-        )
+    # test_circuit
+    if isinstance(circuit_a, TestCircuit):
+        test_circuit_a = circuit_a
 
-    if (qasm_a is not None and qiskit_circuit_a is not None) \
-            or (qasm_a is not None and test_circuit_a is not None) \
-            or (qiskit_circuit_a is not None and test_circuit_a is not None):
-        raise QuantestPyError(
-            "Too much information for circuit A. "
-            "Only one of the following should be given: "
-            "qasm_a, qiskit_circuit_a and test_circuit_a."
-        )
+    # qasm
+    elif isinstance(circuit_a, str):
+        test_circuit_a = _cvt_openqasm_to_test_circuit(circuit_a)
 
-    if qasm_a is not None and not isinstance(qasm_a, str):
-        raise QuantestPyError(
-            "Type of qasm_a must be str."
-        )
+    # qiskit.QuantumCircuit()
+    elif _is_instance_of_qiskit_quantumcircuit(circuit_a):
+        test_circuit_a = _cvt_qiskit_to_test_circuit(circuit_a)
 
-    if qiskit_circuit_a is not None \
-            and not _is_instance_of_qiskit_quantumcircuit(qiskit_circuit_a):
+    else:
         raise QuantestPyError(
-            "Type of qiskit_circuit_a must be an instance of "
-            "qiskit.QuantumCircuit class."
-        )
-
-    if test_circuit_a is not None \
-            and not isinstance(test_circuit_a, TestCircuit):
-        raise QuantestPyError(
-            "Type of test_circuit_a must be an instance of "
-            "quantestpy.TestCircuit class."
+            "circuit_a must be one of the following: "
+            "qasm, qiskit.QuantumCircuit and TestCircuit."
         )
 
     # Check inputs for circuit B
-    if qasm_b is None and qiskit_circuit_b is None and test_circuit_b is None:
-        raise QuantestPyError(
-            "Missing information for circuit B. "
-            "One of the following must be given: "
-            "qasm_b, qiskit_circuit_b and test_circuit_b."
-        )
+    # test_circuit
+    if isinstance(circuit_b, TestCircuit):
+        test_circuit_b = circuit_b
 
-    if (qasm_b is not None and qiskit_circuit_b is not None) \
-            or (qasm_b is not None and test_circuit_b is not None) \
-            or (qiskit_circuit_b is not None and test_circuit_b is not None):
-        raise QuantestPyError(
-            "Too much information for circuit B. "
-            "Only one of the following should be given: "
-            "qasm_b, qiskit_circuit_b and test_circuit_b."
-        )
+    # qasm
+    elif isinstance(circuit_b, str):
+        test_circuit_b = _cvt_openqasm_to_test_circuit(circuit_b)
 
-    if qasm_b is not None and not isinstance(qasm_b, str):
-        raise QuantestPyError(
-            "Type of qasm_b must be str."
-        )
+    # qiskit.QuantumCircuit()
+    elif _is_instance_of_qiskit_quantumcircuit(circuit_b):
+        test_circuit_b = _cvt_qiskit_to_test_circuit(circuit_b)
 
-    if qiskit_circuit_b is not None \
-            and not _is_instance_of_qiskit_quantumcircuit(qiskit_circuit_b):
+    else:
         raise QuantestPyError(
-            "Type of qiskit_circuit_b must be an instance of "
-            "qiskit.QuantumCircuit class."
-        )
-
-    if test_circuit_b is not None \
-            and not isinstance(test_circuit_b, TestCircuit):
-        raise QuantestPyError(
-            "Type of test_circuit_b must be an instance of "
-            "quantestpy.TestCircuit class."
+            "circuit_b must be one of the following: "
+            "qasm, qiskit.QuantumCircuit and TestCircuit."
         )
 
     if matrix_norm_type is not None and matrix_norm_type not in \
@@ -356,20 +318,6 @@ def assert_equal(
         raise QuantestPyError(
             "Type of rtol must be float."
         )
-
-    # cvt. to test_circuit_a
-    if qasm_a is not None:
-        test_circuit_a = _cvt_openqasm_to_test_circuit(qasm_a)
-
-    elif qiskit_circuit_a is not None:
-        test_circuit_a = _cvt_qiskit_to_test_circuit(qiskit_circuit_a)
-
-    # cvt. to test_circuit_b
-    if qasm_b is not None:
-        test_circuit_b = _cvt_openqasm_to_test_circuit(qasm_b)
-
-    elif qiskit_circuit_b is not None:
-        test_circuit_b = _cvt_qiskit_to_test_circuit(qiskit_circuit_b)
 
     whole_gates_a = test_circuit_a._get_whole_gates()
     whole_gates_b = test_circuit_b._get_whole_gates()

--- a/quantestpy/circuit.py
+++ b/quantestpy/circuit.py
@@ -17,34 +17,31 @@ ut_test_case = unittest.TestCase()
 
 
 def assert_equal_to_operator(
+        circuit: Union[TestCircuit, str],
         operator_: Union[np.ndarray, np.matrix],
-        qasm: str = None,
-        qiskit_circuit=None,
-        test_circuit: TestCircuit = None,
         from_right_to_left_for_qubit_ids: bool = False,
         rtol: float = 0.,
         atol: float = 1e-8,
         up_to_global_phase: bool = False,
         msg=None) -> None:
 
-    if qasm is None and qiskit_circuit is None and test_circuit is None:
+    # test_circuit
+    if isinstance(circuit, TestCircuit):
+        test_circuit = circuit
+
+    # qasm
+    elif isinstance(circuit, str):
+        test_circuit = _cvt_openqasm_to_test_circuit(circuit)
+
+    # qiskit.QuantumCircuit()
+    elif _is_instance_of_qiskit_quantumcircuit(circuit):
+        test_circuit = _cvt_qiskit_to_test_circuit(circuit)
+
+    else:
         raise QuantestPyError(
-            "Missing qasm or qiskit_circuit or test circuit."
+            "Input circuit must be one of the following: "
+            "qasm, qiskit.QuantumCircuit and TestCircuit."
         )
-
-    if (qasm is not None and qiskit_circuit is not None) \
-            or (qasm is not None and test_circuit is not None) \
-            or (qiskit_circuit is not None and test_circuit is not None):
-        raise QuantestPyError(
-            "You need to choose one parameter of Qasm, \
-                qiskit_circuit and test circuit."
-        )
-
-    if qasm is not None:
-        test_circuit = _cvt_openqasm_to_test_circuit(qasm)
-
-    if qiskit_circuit is not None:
-        test_circuit = _cvt_qiskit_to_test_circuit(qiskit_circuit)
 
     test_circuit._from_right_to_left_for_qubit_ids = \
         from_right_to_left_for_qubit_ids

--- a/quantestpy/circuit.py
+++ b/quantestpy/circuit.py
@@ -15,15 +15,8 @@ from quantestpy.converter import _is_instance_of_qiskit_quantumcircuit
 ut_test_case = unittest.TestCase()
 
 
-def assert_equal_to_operator(
-        circuit: Union[TestCircuit, str],
-        operator_: Union[np.ndarray, np.matrix],
-        from_right_to_left_for_qubit_ids: bool = False,
-        rtol: float = 0.,
-        atol: float = 1e-8,
-        up_to_global_phase: bool = False,
-        matrix_norm_type: Union[str, None] = None,
-        msg=None) -> None:
+def _get_test_circuit_from_input_circuit(circuit: Union[TestCircuit, str]) \
+        -> TestCircuit:
 
     # test_circuit
     if isinstance(circuit, TestCircuit):
@@ -42,6 +35,21 @@ def assert_equal_to_operator(
             "Input circuit must be one of the following: "
             "qasm, qiskit.QuantumCircuit and TestCircuit."
         )
+
+    return test_circuit
+
+
+def assert_equal_to_operator(
+        circuit: Union[TestCircuit, str],
+        operator_: Union[np.ndarray, np.matrix],
+        from_right_to_left_for_qubit_ids: bool = False,
+        rtol: float = 0.,
+        atol: float = 1e-8,
+        up_to_global_phase: bool = False,
+        matrix_norm_type: Union[str, None] = None,
+        msg=None) -> None:
+
+    test_circuit = _get_test_circuit_from_input_circuit(circuit)
 
     test_circuit._from_right_to_left_for_qubit_ids = \
         from_right_to_left_for_qubit_ids
@@ -64,28 +72,12 @@ def assert_is_zero(circuit: Union[TestCircuit, str],
                    atol: float = 1e-8,
                    msg=None) -> None:
 
-    # test_circuit
-    if isinstance(circuit, TestCircuit):
-        test_circuit = circuit
-
-    # qasm
-    elif isinstance(circuit, str):
-        test_circuit = _cvt_openqasm_to_test_circuit(circuit)
-
-    # qiskit.QuantumCircuit()
-    elif _is_instance_of_qiskit_quantumcircuit(circuit):
-        test_circuit = _cvt_qiskit_to_test_circuit(circuit)
-
-    else:
-        raise QuantestPyError(
-            "Input circuit must be one of the following: "
-            "qasm, qiskit.QuantumCircuit and TestCircuit."
-        )
-
     if not isinstance(qubits, list) and qubits is not None:
         raise QuantestPyError(
             "qubits must be a list of integer(s) as qubit's ID(s)."
         )
+
+    test_circuit = _get_test_circuit_from_input_circuit(circuit)
 
     state_vec = test_circuit._get_state_vector()
     num_qubit = test_circuit._num_qubit
@@ -130,28 +122,12 @@ def assert_ancilla_is_zero(circuit: Union[TestCircuit, str],
                            atol: float = 1e-8,
                            msg=None) -> None:
 
-    # test_circuit
-    if isinstance(circuit, TestCircuit):
-        test_circuit = circuit
-
-    # qasm
-    elif isinstance(circuit, str):
-        test_circuit = _cvt_openqasm_to_test_circuit(circuit)
-
-    # qiskit.QuantumCircuit()
-    elif _is_instance_of_qiskit_quantumcircuit(circuit):
-        test_circuit = _cvt_qiskit_to_test_circuit(circuit)
-
-    else:
-        raise QuantestPyError(
-            "Input circuit must be one of the following: "
-            "qasm, qiskit.QuantumCircuit and TestCircuit."
-        )
-
     if not isinstance(ancilla_qubits, list):
         raise QuantestPyError(
             "ancilla_qubits must be a list of integer(s) as qubit's ID(s)."
         )
+
+    test_circuit = _get_test_circuit_from_input_circuit(circuit)
 
     num_qubit = test_circuit._num_qubit
 
@@ -220,44 +196,6 @@ def assert_equal(
         matrix_norm_type: Union[str, None] = None,
         msg: Union[str, None] = None):
 
-    # Check inputs for circuit A
-    # test_circuit
-    if isinstance(circuit_a, TestCircuit):
-        test_circuit_a = circuit_a
-
-    # qasm
-    elif isinstance(circuit_a, str):
-        test_circuit_a = _cvt_openqasm_to_test_circuit(circuit_a)
-
-    # qiskit.QuantumCircuit()
-    elif _is_instance_of_qiskit_quantumcircuit(circuit_a):
-        test_circuit_a = _cvt_qiskit_to_test_circuit(circuit_a)
-
-    else:
-        raise QuantestPyError(
-            "circuit_a must be one of the following: "
-            "qasm, qiskit.QuantumCircuit and TestCircuit."
-        )
-
-    # Check inputs for circuit B
-    # test_circuit
-    if isinstance(circuit_b, TestCircuit):
-        test_circuit_b = circuit_b
-
-    # qasm
-    elif isinstance(circuit_b, str):
-        test_circuit_b = _cvt_openqasm_to_test_circuit(circuit_b)
-
-    # qiskit.QuantumCircuit()
-    elif _is_instance_of_qiskit_quantumcircuit(circuit_b):
-        test_circuit_b = _cvt_qiskit_to_test_circuit(circuit_b)
-
-    else:
-        raise QuantestPyError(
-            "circuit_b must be one of the following: "
-            "qasm, qiskit.QuantumCircuit and TestCircuit."
-        )
-
     if matrix_norm_type is not None and matrix_norm_type not in \
         ["operator_norm_1", "operator_norm_2",
          "operator_norm_inf", "Frobenius_norm", "max_norm"]:
@@ -277,6 +215,9 @@ def assert_equal(
         raise QuantestPyError(
             "Type of rtol must be float."
         )
+
+    test_circuit_a = _get_test_circuit_from_input_circuit(circuit_a)
+    test_circuit_b = _get_test_circuit_from_input_circuit(circuit_b)
 
     whole_gates_a = test_circuit_a._get_whole_gates()
     whole_gates_b = test_circuit_b._get_whole_gates()

--- a/test/test_circuit_assert_ancilla_is_zero.py
+++ b/test/test_circuit_assert_ancilla_is_zero.py
@@ -12,9 +12,9 @@ class TestCircuitAssertAncillaIsZero(unittest.TestCase):
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
     $ python -m unittest test.test_circuit_assert_ancilla_is_zero
-    ...
+    ..
     ----------------------------------------------------------------------
-    Ran 2 tests in 0.017s
+    Ran 2 tests in 0.135s
 
     OK
     """
@@ -49,7 +49,7 @@ class TestCircuitAssertAncillaIsZero(unittest.TestCase):
 
         self.assertIsNone(
             circuit.assert_ancilla_is_zero(
-                test_circuit=test_circuit,
+                circuit=test_circuit,
                 ancilla_qubits=[1, 2]
             )
         )
@@ -85,7 +85,7 @@ class TestCircuitAssertAncillaIsZero(unittest.TestCase):
         try:
             self.assertIsNotNone(
                 circuit.assert_ancilla_is_zero(
-                    test_circuit=test_circuit,
+                    circuit=test_circuit,
                     ancilla_qubits=[1, 2]
                 )
             )

--- a/test/test_circuit_assert_equal_to_operator.py
+++ b/test/test_circuit_assert_equal_to_operator.py
@@ -12,7 +12,7 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
     $ python -m unittest test.test_circuit_assert_equal_to_operator
-    ........
+    ....
     ----------------------------------------------------------------------
     Ran 4 tests in 0.003s
 
@@ -45,7 +45,7 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
         self.assertIsNone(
             circuit.assert_equal_to_operator(
                 operator_=expected_operator,
-                test_circuit=self.test_circ
+                circuit=self.test_circ
             )
         )
 
@@ -61,7 +61,7 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
         with self.assertRaises(QuantestPyAssertionError):
             circuit.assert_equal_to_operator(
                 operator_=expected_operator,
-                test_circuit=self.test_circ,
+                circuit=self.test_circ,
                 from_right_to_left_for_qubit_ids=True  # Qiskit convention
             )
 
@@ -77,7 +77,7 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
         self.assertIsNone(
             circuit.assert_equal_to_operator(
                 operator_=expected_operator,
-                test_circuit=self.test_circ,
+                circuit=self.test_circ,
                 from_right_to_left_for_qubit_ids=True  # Qiskit convention
             )
         )
@@ -94,5 +94,5 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
         with self.assertRaises(QuantestPyAssertionError):
             circuit.assert_equal_to_operator(
                 operator_=expected_operator,
-                test_circuit=self.test_circ
+                circuit=self.test_circ
             )

--- a/test/test_circuit_assert_is_zero.py
+++ b/test/test_circuit_assert_is_zero.py
@@ -11,9 +11,9 @@ class TestCircuitAssertIsZero(unittest.TestCase):
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
     $ python -m unittest test.test_circuit_assert_is_zero
-    ...
+    ....
     ----------------------------------------------------------------------
-    Ran 3 tests in 0.006s
+    Ran 4 tests in 0.008s
 
     OK
     """
@@ -31,7 +31,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
 
         self.assertIsNone(
             circuit.assert_is_zero(
-                test_circuit=test_circuit,
+                circuit=test_circuit,
                 qubits=[1]
             )
         )
@@ -49,7 +49,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
 
         self.assertIsNone(
             circuit.assert_is_zero(
-                test_circuit=test_circuit,
+                circuit=test_circuit,
                 qubits=[1, 2]
             )
         )
@@ -67,7 +67,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
 
         with self.assertRaises(QuantestPyAssertionError):
             circuit.assert_is_zero(
-                test_circuit=test_circuit
+                circuit=test_circuit
             )
 
     def test_large_a_tol_raise_no_error(self,):
@@ -86,7 +86,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
         # no error
         self.assertIsNone(
             circuit.assert_is_zero(
-                test_circuit=test_circuit,
+                circuit=test_circuit,
                 atol=0.71
             )
         )
@@ -94,6 +94,6 @@ class TestCircuitAssertIsZero(unittest.TestCase):
         # error
         with self.assertRaises(QuantestPyAssertionError):
             circuit.assert_is_zero(
-                test_circuit=test_circuit,
+                circuit=test_circuit,
                 atol=0.7
             )

--- a/test/with_qiskit/test_circuit_assert_equal.py
+++ b/test/with_qiskit/test_circuit_assert_equal.py
@@ -14,7 +14,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_circuit_assert_equal
+    $ python -m unittest test.with_qiskit.test_circuit_assert_equal
     ...
     ----------------------------------------------------------------------
     Ran 3 tests in 0.006s
@@ -22,215 +22,55 @@ class TestCircuitAssertEqual(unittest.TestCase):
     OK
     """
 
-    def test_msg_from_miss_all_info_for_circuit_a(self,):
-        test_circuit = TestCircuit(2)
-
-        try:
-            self.assertIsNotNone(
-                circuit.assert_equal(
-                    test_circuit_b=test_circuit
-                )
-            )
-
-        except QuantestPyError as e:
-
-            expected_error_msg = "quantestpy.exceptions.QuantestPyError: " \
-                + "Missing information for circuit A. " \
-                + "One of the following must be given: " \
-                + "qasm_a, qiskit_circuit_a and test_circuit_a.\n"
-
-            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
-
-            self.assertEqual(expected_error_msg, actual_error_msg)
-
-    def test_msg_from_miss_all_info_for_circuit_b(self,):
-        test_circuit = TestCircuit(3)
-
-        try:
-            self.assertIsNotNone(
-                circuit.assert_equal(
-                    test_circuit_a=test_circuit
-                )
-            )
-
-        except QuantestPyError as e:
-
-            expected_error_msg = "quantestpy.exceptions.QuantestPyError: " \
-                + "Missing information for circuit B. " \
-                + "One of the following must be given: " \
-                + "qasm_b, qiskit_circuit_b and test_circuit_b.\n"
-
-            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
-
-            self.assertEqual(expected_error_msg, actual_error_msg)
-
-    def test_msg_from_too_much_info_for_circuit_a(self,):
-
-        qasm = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[2];\nx q[0];\n'
-        qiskit_circuit = QuantumCircuit(2)
-        test_circuit = TestCircuit(3)
-
-        test_circuit_b = TestCircuit(2)
-
-        test_patterns = [
-            (qasm, None, test_circuit),
-            (None, qiskit_circuit, test_circuit),
-            (qasm, qiskit_circuit, None),
-            (qasm, qiskit_circuit, test_circuit)
-        ]
-
-        for _qasm, _qiskit_circuit, _test_circuit in test_patterns:
-
-            try:
-                self.assertIsNotNone(
-                    circuit.assert_equal(
-                        qasm_a=_qasm,
-                        qiskit_circuit_a=_qiskit_circuit,
-                        test_circuit_a=_test_circuit,
-                        test_circuit_b=test_circuit_b
-                    )
-                )
-
-            except QuantestPyError as e:
-
-                expected_error_msg = \
-                    "quantestpy.exceptions.QuantestPyError: " \
-                    + "Too much information for circuit A. " \
-                    + "Only one of the following should be given: " \
-                    + "qasm_a, qiskit_circuit_a and test_circuit_a.\n"
-
-                actual_error_msg = \
-                    traceback.format_exception_only(type(e), e)[0]
-
-                self.assertEqual(expected_error_msg, actual_error_msg)
-
-    def test_msg_from_too_much_info_for_circuit_b(self,):
-
-        qasm = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[2];\nx q[0];\n'
-        qiskit_circuit = QuantumCircuit(2)
-        test_circuit = TestCircuit(2)
-
-        test_circuit_a = TestCircuit(2)
-
-        test_patterns = [
-            (qasm, None, test_circuit),
-            (None, qiskit_circuit, test_circuit),
-            (qasm, qiskit_circuit, None),
-            (qasm, qiskit_circuit, test_circuit)
-        ]
-
-        for _qasm, _qiskit_circuit, _test_circuit in test_patterns:
-
-            try:
-                self.assertIsNotNone(
-                    circuit.assert_equal(
-                        qasm_b=_qasm,
-                        qiskit_circuit_b=_qiskit_circuit,
-                        test_circuit_b=_test_circuit,
-                        test_circuit_a=test_circuit_a
-                    )
-                )
-
-            except QuantestPyError as e:
-
-                expected_error_msg = \
-                    "quantestpy.exceptions.QuantestPyError: " \
-                    + "Too much information for circuit B. " \
-                    + "Only one of the following should be given: " \
-                    + "qasm_b, qiskit_circuit_b and test_circuit_b.\n"
-
-                actual_error_msg = \
-                    traceback.format_exception_only(type(e), e)[0]
-
-                self.assertEqual(expected_error_msg, actual_error_msg)
-
     def test_msg_from_wrong_input_type_for_circuit_a(self,):
-        qasm = 1  # wrong type
-        qiskit_circuit = "hoge"  # wrong type
-        test_circuit = QuantumCircuit(2)  # wrong type
 
-        test_circuit_b = TestCircuit(2)
+        circuit_a = np.array([[0, 1], [1, 0]])  # wrong
+        circuit_b = TestCircuit(2)  # correct
 
-        test_patterns = [
-            {"argument": [qasm, None, None],
-             "circuit_option": "qasm_a",
-             "expected_type": "str"},
-            {"argument": [None, qiskit_circuit, None],
-             "circuit_option": "qiskit_circuit_a",
-             "expected_type": "an instance of qiskit.QuantumCircuit class"},
-            {"argument": [None, None, test_circuit],
-             "circuit_option": "test_circuit_a",
-             "expected_type": "an instance of quantestpy.TestCircuit class"}
-        ]
-
-        for pattern in test_patterns:
-            _qasm, _qiskit_circuit, _test_circuit = pattern["argument"]
-
-            try:
-                self.assertIsNotNone(
-                    circuit.assert_equal(
-                        qasm_a=_qasm,
-                        qiskit_circuit_a=_qiskit_circuit,
-                        test_circuit_a=_test_circuit,
-                        test_circuit_b=test_circuit_b
-                    )
+        try:
+            self.assertIsNotNone(
+                circuit.assert_equal(
+                    circuit_a=circuit_a,
+                    circuit_b=circuit_b
                 )
+            )
 
-            except QuantestPyError as e:
+        except QuantestPyError as e:
 
-                expected_error_msg = \
-                    "quantestpy.exceptions.QuantestPyError: " \
-                    + f'Type of {pattern["circuit_option"]} must be ' \
-                    + f'{pattern["expected_type"]}.\n'
+            expected_error_msg = \
+                "quantestpy.exceptions.QuantestPyError: " \
+                + "circuit_a must be one of the following: " \
+                + "qasm, qiskit.QuantumCircuit and TestCircuit.\n"
 
-                actual_error_msg = \
-                    traceback.format_exception_only(type(e), e)[0]
+            actual_error_msg = \
+                traceback.format_exception_only(type(e), e)[0]
 
-                self.assertEqual(expected_error_msg, actual_error_msg)
+            self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_msg_from_wrong_input_type_for_circuit_b(self,):
-        qasm = QuantumCircuit(2)  # wrong type
-        qiskit_circuit = TestCircuit(2)  # wrong type
-        test_circuit = 3  # wrong type
 
-        test_circuit_a = TestCircuit(2)
+        circuit_a = QuantumCircuit(3)  # correct
+        circuit_b = [[0, 1], [1, 0]]  # wrong
 
-        test_patterns = [
-            {"argument": [qasm, None, None],
-             "circuit_option": "qasm_b",
-             "expected_type": "str"},
-            {"argument": [None, qiskit_circuit, None],
-             "circuit_option": "qiskit_circuit_b",
-             "expected_type": "an instance of qiskit.QuantumCircuit class"},
-            {"argument": [None, None, test_circuit],
-             "circuit_option": "test_circuit_b",
-             "expected_type": "an instance of quantestpy.TestCircuit class"}
-        ]
-
-        for pattern in test_patterns:
-            _qasm, _qiskit_circuit, _test_circuit = pattern["argument"]
-
-            try:
-                self.assertIsNotNone(
-                    circuit.assert_equal(
-                        qasm_b=_qasm,
-                        qiskit_circuit_b=_qiskit_circuit,
-                        test_circuit_b=_test_circuit,
-                        test_circuit_a=test_circuit_a
-                    )
+        try:
+            self.assertIsNotNone(
+                circuit.assert_equal(
+                    circuit_a=circuit_a,
+                    circuit_b=circuit_b
                 )
+            )
 
-            except QuantestPyError as e:
+        except QuantestPyError as e:
 
-                expected_error_msg = \
-                    "quantestpy.exceptions.QuantestPyError: " \
-                    + f'Type of {pattern["circuit_option"]} must be ' \
-                    + f'{pattern["expected_type"]}.\n'
+            expected_error_msg = \
+                "quantestpy.exceptions.QuantestPyError: " \
+                + "circuit_b must be one of the following: " \
+                + "qasm, qiskit.QuantumCircuit and TestCircuit.\n"
 
-                actual_error_msg = \
-                    traceback.format_exception_only(type(e), e)[0]
+            actual_error_msg = \
+                traceback.format_exception_only(type(e), e)[0]
 
-                self.assertEqual(expected_error_msg, actual_error_msg)
+            self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_exact_equal(self,):
         """Check CNOT basis transformation; see Nielsen-Chuang p.179"""
@@ -256,8 +96,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
         self.assertIsNone(
             circuit.assert_equal(
-                test_circuit_a=test_circuit_a,
-                test_circuit_b=test_circuit_b
+                circuit_a=test_circuit_a,
+                circuit_b=test_circuit_b
             )
         )
 
@@ -303,8 +143,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
             try:
                 self.assertIsNotNone(
                     circuit.assert_equal(
-                        test_circuit_a=test_circuit_a,
-                        test_circuit_b=test_circuit_b,
+                        circuit_a=test_circuit_a,
+                        circuit_b=test_circuit_b,
                         atol=tolerance
                     )
                 )
@@ -358,8 +198,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
             try:
                 self.assertIsNotNone(
                     circuit.assert_equal(
-                        test_circuit_a=test_circuit_a,
-                        test_circuit_b=test_circuit_b,
+                        circuit_a=test_circuit_a,
+                        circuit_b=test_circuit_b,
                         matrix_norm_type=pattern["matrix_norm_type"],
                         atol=pattern["atol"]
                     )
@@ -397,8 +237,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
         try:
             self.assertIsNotNone(
                 circuit.assert_equal(
-                    test_circuit_a=test_circuit_a,
-                    test_circuit_b=test_circuit_b,
+                    circuit_a=test_circuit_a,
+                    circuit_b=test_circuit_b,
                     matrix_norm_type="operator_norm_2",
                     atol=1.5
                 )
@@ -459,8 +299,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
             try:
                 self.assertIsNotNone(
                     circuit.assert_equal(
-                        test_circuit_a=test_circuit_a,
-                        test_circuit_b=test_circuit_b,
+                        circuit_a=test_circuit_a,
+                        circuit_b=test_circuit_b,
                         matrix_norm_type=pattern["matrix_norm_type"],
                         atol=0.,
                         rtol=pattern["rtol"]

--- a/test/with_qiskit/test_circuit_assert_equal.py
+++ b/test/with_qiskit/test_circuit_assert_equal.py
@@ -39,7 +39,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
             expected_error_msg = \
                 "quantestpy.exceptions.QuantestPyError: " \
-                + "circuit_a must be one of the following: " \
+                + "Input circuit must be one of the following: " \
                 + "qasm, qiskit.QuantumCircuit and TestCircuit.\n"
 
             actual_error_msg = \
@@ -64,7 +64,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
             expected_error_msg = \
                 "quantestpy.exceptions.QuantestPyError: " \
-                + "circuit_b must be one of the following: " \
+                + "Input circuit must be one of the following: " \
                 + "qasm, qiskit.QuantumCircuit and TestCircuit.\n"
 
             actual_error_msg = \


### PR DESCRIPTION
Input circuits `[qasm, qiskit_circuit, test_circuit]` are unified to `circuit` at the 4 assert methods in circuit.py 