### PR TITLE
Add a missing abs() when comparing with atol in operator.assert_is_unitary()

### DIFF
--- a/quantestpy/operator.py
+++ b/quantestpy/operator.py
@@ -20,7 +20,7 @@ def assert_is_unitary(
 
     a = m * m.H
 
-    if np.all(a - np.eye(m.shape[0]) <= atol):
+    if np.all(np.abs(a - np.eye(m.shape[0])) <= atol):
         return
 
     else:


### PR DESCRIPTION
I realized this error when writing the doc for this method... 😞 