### PR TITLE
[WIP] Add FastTestCircuit class and an assertion method for unary iteration

### DIFF
--- a/quantestpy/__init__.py
+++ b/quantestpy/__init__.py
@@ -1,1 +1,2 @@
 from .test_circuit import TestCircuit
+from .fast_test_circuit import FastTestCircuit

--- a/quantestpy/__init__.py
+++ b/quantestpy/__init__.py
@@ -1,2 +1,2 @@
-from .test_circuit import TestCircuit
 from .fast_test_circuit import FastTestCircuit
+from .test_circuit import TestCircuit

--- a/quantestpy/fast_test_circuit.py
+++ b/quantestpy/fast_test_circuit.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from quantestpy.exceptions import QuantestPyTestCircuitError, QuantestPyError
+from quantestpy.exceptions import QuantestPyError, QuantestPyTestCircuitError
 from quantestpy.test_circuit import TestCircuit
 
 _IMPLEMENTED_GATES = ["x", "y", "z", "swap"]

--- a/quantestpy/fast_test_circuit.py
+++ b/quantestpy/fast_test_circuit.py
@@ -14,6 +14,7 @@ class FastTestCircuit(TestCircuit):
         self._qubit_phase = np.array([0. for _ in range(num_qubit)])
 
     def add_gate(self, gate: dict) -> None:
+        gate["parameter"] = []  # to avoid error
         if gate["name"] not in _IMPLEMENTED_GATES:
             raise QuantestPyTestCircuitError(
                 f'{gate["name"]} is not implemented.'

--- a/quantestpy/fast_test_circuit.py
+++ b/quantestpy/fast_test_circuit.py
@@ -62,41 +62,6 @@ class FastTestCircuit(TestCircuit):
 
         self._qubit_value[qubit_id] = qubit_value
 
-    def set_qubit_phase(self, qubit_id: list, qubit_phase: list):
-        if not isinstance(qubit_id, list):
-            raise QuantestPyTestCircuitError(
-                "qubit_id must be a list."
-            )
-
-        if not isinstance(qubit_phase, list):
-            raise QuantestPyTestCircuitError(
-                "qubit_phase must be a list."
-            )
-
-        if len(qubit_id) != len(qubit_phase):
-            raise QuantestPyTestCircuitError(
-                "size of qubit_id must be the same with that of qubit_phase."
-            )
-
-        for id in qubit_id:
-            if not isinstance(id, int):
-                raise QuantestPyTestCircuitError(
-                    "elements in qubit_id must be integer."
-                )
-
-            if id >= self._num_qubit:
-                raise QuantestPyTestCircuitError(
-                    f"qubit_id {id} is out of range."
-                )
-
-        for phase in qubit_phase:
-            if not isinstance(phase, int) and not isinstance(phase, float):
-                raise QuantestPyTestCircuitError(
-                    "elements in qubit_value must be real number."
-                )
-
-        self._qubit_phase[qubit_id] = qubit_phase
-
     def _execute_x_gate(self, target_qubit: list) -> None:
         self._qubit_value[target_qubit] ^= 1
 

--- a/quantestpy/fast_test_circuit.py
+++ b/quantestpy/fast_test_circuit.py
@@ -1,0 +1,150 @@
+import numpy as np
+
+from quantestpy.exceptions import QuantestPyTestCircuitError
+from quantestpy.test_circuit import TestCircuit
+
+_IMPLEMENTED_GATES = ["x", "y", "z", "swap"]
+
+
+class FastTestCircuit(TestCircuit):
+
+    def __init__(self, num_qubit: int):
+        super().__init__(num_qubit=num_qubit)
+        self._qubit_value = np.array([0 for _ in range(num_qubit)])
+        self._qubit_phase = np.array([0. for _ in range(num_qubit)])
+
+    def add_gate(self, gate: dict) -> None:
+        if gate["name"] not in _IMPLEMENTED_GATES:
+            raise QuantestPyTestCircuitError(
+                f'{gate["name"]} is not implemented.'
+                f'Implemented gates: {_IMPLEMENTED_GATES}'
+            )
+        super().add_gate(gate=gate)
+
+    def set_qubit_value(self, qubit_id: list, qubit_value: list):
+        if not isinstance(qubit_id, list):
+            raise QuantestPyTestCircuitError(
+                "qubit_id must be a list."
+            )
+
+        if not isinstance(qubit_value, list):
+            raise QuantestPyTestCircuitError(
+                "qubit_value must be a list."
+            )
+
+        if len(qubit_id) != len(qubit_value):
+            raise QuantestPyTestCircuitError(
+                "size of qubit_id must be the same with that of qubit_value."
+            )
+
+        for id in qubit_id:
+            if not isinstance(id, int):
+                raise QuantestPyTestCircuitError(
+                    "elements in qubit_id must be integer."
+                )
+
+            if id >= self._num_qubit:
+                raise QuantestPyTestCircuitError(
+                    f"qubit_id {id} is out of range."
+                )
+
+        for value in qubit_value:
+            if not isinstance(value, int):
+                raise QuantestPyTestCircuitError(
+                    "elements in qubit_value must be integer."
+                )
+
+            if value not in [0, 1]:
+                raise QuantestPyTestCircuitError(
+                    "elements in qubit_value must be either 0 or 1."
+                )
+
+        self._qubit_value[qubit_id] = qubit_value
+
+    def set_qubit_phase(self, qubit_id: list, qubit_phase: list):
+        if not isinstance(qubit_id, list):
+            raise QuantestPyTestCircuitError(
+                "qubit_id must be a list."
+            )
+
+        if not isinstance(qubit_phase, list):
+            raise QuantestPyTestCircuitError(
+                "qubit_phase must be a list."
+            )
+
+        if len(qubit_id) != len(qubit_phase):
+            raise QuantestPyTestCircuitError(
+                "size of qubit_id must be the same with that of qubit_phase."
+            )
+
+        for id in qubit_id:
+            if not isinstance(id, int):
+                raise QuantestPyTestCircuitError(
+                    "elements in qubit_id must be integer."
+                )
+
+            if id >= self._num_qubit:
+                raise QuantestPyTestCircuitError(
+                    f"qubit_id {id} is out of range."
+                )
+
+        for phase in qubit_phase:
+            if not isinstance(phase, int) and not isinstance(phase, float):
+                raise QuantestPyTestCircuitError(
+                    "elements in qubit_value must be real number."
+                )
+
+        self._qubit_phase[qubit_id] = qubit_phase
+
+    def _execute_x_gate(self, target_qubit: list) -> None:
+        self._qubit_value[target_qubit] ^= 1
+
+    def _execute_y_gate(self, target_qubit: list) -> None:
+        self._qubit_phase[target_qubit] \
+            += np.pi * (0.5 - self._qubit_value[target_qubit])
+        self._qubit_value[target_qubit] ^= 1
+
+    def _execute_z_gate(self, target_qubit: list) -> None:
+        self._qubit_phase[target_qubit] \
+            += np.pi * self._qubit_value[target_qubit]
+
+    def _execute_swap_gate(self, target_qubit: list) -> None:
+        a = self._qubit_value[target_qubit[0]]
+        b = self._qubit_value[target_qubit[1]]
+        self._qubit_value[target_qubit[0]] = b
+        self._qubit_value[target_qubit[1]] = a
+
+    def execute_all_gates(self,) -> None:
+        for gate in self._gates:
+            if len(gate["control_qubit"]) == 0 or \
+                np.all(self._qubit_value[gate["control_qubit"]]
+                       == gate["control_value"]):
+
+                if gate["name"] == "x":
+                    self._execute_x_gate(gate["target_qubit"])
+                elif gate["name"] == "y":
+                    self._execute_y_gate(gate["target_qubit"])
+                elif gate["name"] == "z":
+                    self._execute_z_gate(gate["target_qubit"])
+                elif gate["name"] == "swap":
+                    self._execute_swap_gate(gate["target_qubit"])
+                else:
+                    raise
+
+
+if __name__ == "__main__":
+    """Example showing how to use FastTestCircuit class."""
+
+    ftc = FastTestCircuit(5)
+    ftc.add_gate({"name": "y", "target_qubit": [0], "control_qubit": [],
+                  "control_value": [], "parameter": []})
+    ftc.add_gate({"name": "x", "target_qubit": [1], "control_qubit": [],
+                  "control_value": [], "parameter": []})
+    ftc.add_gate({"name": "z", "target_qubit": [3], "control_qubit": [0, 1],
+                  "control_value": [1, 1], "parameter": []})
+    ftc.add_gate({"name": "swap", "target_qubit": [3, 1], "control_qubit": [0],
+                  "control_value": [1], "parameter": []})
+
+    ftc.execute_all_gates()
+    print(ftc._qubit_value)
+    print(ftc._qubit_phase)

--- a/quantestpy/fast_test_circuit.py
+++ b/quantestpy/fast_test_circuit.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from quantestpy.exceptions import QuantestPyTestCircuitError
+from quantestpy.exceptions import QuantestPyTestCircuitError, QuantestPyError
 from quantestpy.test_circuit import TestCircuit
 
 _IMPLEMENTED_GATES = ["x", "y", "z", "swap"]
@@ -80,22 +80,36 @@ class FastTestCircuit(TestCircuit):
         self._qubit_value[target_qubit[0]] = b
         self._qubit_value[target_qubit[1]] = a
 
-    def execute_all_gates(self,) -> None:
-        for gate in self._gates:
-            if len(gate["control_qubit"]) == 0 or \
-                np.all(self._qubit_value[gate["control_qubit"]]
-                       == gate["control_value"]):
+    def execute_one_gate(self, gate_number: int) -> None:
+        if not isinstance(gate_number, int):
+            raise QuantestPyTestCircuitError(
+                "gate_number must be an integer."
+            )
 
-                if gate["name"] == "x":
-                    self._execute_x_gate(gate["target_qubit"])
-                elif gate["name"] == "y":
-                    self._execute_y_gate(gate["target_qubit"])
-                elif gate["name"] == "z":
-                    self._execute_z_gate(gate["target_qubit"])
-                elif gate["name"] == "swap":
-                    self._execute_swap_gate(gate["target_qubit"])
-                else:
-                    raise
+        if gate_number >= len(self._gates) or gate_number < 0:
+            raise QuantestPyTestCircuitError(
+                "gate_number is out of range."
+            )
+
+        gate = self._gates[gate_number]
+        if len(gate["control_qubit"]) == 0 or \
+            np.all(self._qubit_value[gate["control_qubit"]]
+                   == gate["control_value"]):
+
+            if gate["name"] == "x":
+                self._execute_x_gate(gate["target_qubit"])
+            elif gate["name"] == "y":
+                self._execute_y_gate(gate["target_qubit"])
+            elif gate["name"] == "z":
+                self._execute_z_gate(gate["target_qubit"])
+            elif gate["name"] == "swap":
+                self._execute_swap_gate(gate["target_qubit"])
+            else:
+                raise QuantestPyError("Unexpected error. Please report.")
+
+    def execute_all_gates(self,) -> None:
+        for i in range(len(self._gates)):
+            self.execute_ith_gate(i)
 
 
 if __name__ == "__main__":

--- a/quantestpy/unary_iteration.py
+++ b/quantestpy/unary_iteration.py
@@ -302,3 +302,85 @@ def assert_check_control_values_for_operations_on_system_register(
 
         print(f"l_binary rep.: {l_binary_rep},",
               f"control qubit values: {control_qubit_values}")
+
+
+def assert_equal_control_values_for_operations_on_system_register(
+        circuit: FastTestCircuit,
+        expected_selection_register_value_to_control_value: dict,
+        selection_register_qubits: list,
+        system_register_qubits: list,
+        accumulator_qubits: list = [],
+        control_qubits: list = [],
+        control_values: list = [],
+        ancilla_register_qubits: list = [],
+        msg=None):
+
+    user_ftc = copy.deepcopy(circuit)
+
+    for l_binary_rep, expected_control_qubit_values in \
+            expected_selection_register_value_to_control_value.items():
+
+        # set all control qubits to active in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=control_qubits,
+            qubit_value=control_values
+        )
+        # initialize all the ancilla qubits to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=ancilla_register_qubits,
+            qubit_value=[0] * len(ancilla_register_qubits)
+        )
+        # initialize the accumulator to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=accumulator_qubits,
+            qubit_value=[0] * len(accumulator_qubits)
+        )
+        # initialize the selection register to l_binary_rep
+        user_ftc.set_qubit_value(
+            qubit_id=selection_register_qubits,
+            qubit_value=[int(i) for i in l_binary_rep]
+        )
+
+        control_qubit_values = []
+        for i, gate in enumerate(user_ftc._gates):
+
+            if np.all([qubit in system_register_qubits for qubit
+                       in gate["target_qubit"]]):
+                control_qubit = gate["control_qubit"]
+                control_qubit_values.append(
+                    user_ftc._qubit_value[control_qubit].tolist())
+
+            else:
+                user_ftc.execute_one_gate(i)
+
+        if len(control_qubit_values) != len(expected_control_qubit_values):
+            error_msg = "The number of operations is not as expected " \
+                + f"when input to selection register is {l_binary_rep}: \n" \
+                + f"expect: {len(expected_control_qubit_values)} \n" \
+                + f"actual: {len(control_qubit_values)}"
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+        if not np.allclose(control_qubit_values,
+                           expected_control_qubit_values):
+            error_msg = "control qubit value(s) are not equal to your " \
+                + "expectation when input to selection register is " \
+                + f"{l_binary_rep}: \n" \
+                + f"expect: {expected_control_qubit_values} \n" \
+                + f"actual: {control_qubit_values}"
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+        # check all ancillas are back to 0
+        if not np.all(user_ftc._qubit_value[ancilla_register_qubits] == 0):
+            error_msg = "ancilla qubit(s) are not back to 0 when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+        # check accumulator is back to 0
+        if not np.all(user_ftc._qubit_value[accumulator_qubits] == 0):
+            error_msg = "accumulator is not back to 0 when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)

--- a/quantestpy/unary_iteration.py
+++ b/quantestpy/unary_iteration.py
@@ -77,3 +77,170 @@ def assert_equal_single_operation(
                 + f"input to selection register is {l_binary_rep}."
             msg = ut_test_case._formatMessage(msg, error_msg)
             raise QuantestPyAssertionError(msg)
+
+
+def assert_equal_ranged_operation(
+        circuit: FastTestCircuit,
+        selection_register_qubits: list,
+        system_register_qubits: list,
+        accumulator_qubit: list,
+        control_qubits: list = [],
+        control_values: list = [],
+        ancilla_register_qubits: list = [],
+        verbose: bool = False,
+        msg=None):
+
+    user_ftc = copy.deepcopy(circuit)
+    size_selection_register = len(selection_register_qubits)
+    size_system_register = len(system_register_qubits)
+
+    # cvt all opearations to X
+    for i, gate in enumerate(user_ftc._gates):
+        if len(gate["target_qubit"]) == 1 and \
+            gate["target_qubit"][0] in system_register_qubits and \
+                gate["control_qubit"][0] in accumulator_qubit:
+            user_ftc._gates[i]["name"] = "x"
+
+    # execute ftc for all computational bases of selection_register
+    for l_ in range(size_system_register):
+        l_binary_rep = ("0" * size_selection_register +
+                        bin(l_)[2:])[-size_selection_register:]
+
+        # set all control qubits to active in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=control_qubits,
+            qubit_value=control_values
+        )
+        # initialize all system register qubits to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=system_register_qubits,
+            qubit_value=[0] * size_system_register
+        )
+        # initialize all the ancilla qubits to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=ancilla_register_qubits,
+            qubit_value=[0] * len(ancilla_register_qubits)
+        )
+        # initialize the accumulator to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=accumulator_qubit,
+            qubit_value=[0]
+        )
+        # initialize the selection register to l_binary_rep
+        user_ftc.set_qubit_value(
+            qubit_id=selection_register_qubits,
+            qubit_value=[int(i) for i in l_binary_rep]
+        )
+        user_ftc.execute_all_gates()
+
+        if verbose:
+            print(l_, user_ftc._qubit_value[system_register_qubits])
+
+        expected_qubit_value_of_system_register_qubits = \
+            np.array([0]*size_system_register)
+        expected_qubit_value_of_system_register_qubits[:l_] = 1
+
+        # check assert equal
+        if not np.all(expected_qubit_value_of_system_register_qubits
+                      == user_ftc._qubit_value[system_register_qubits]):
+            error_msg = "output from system register is not correct when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+        # check all ancillas are back to 0
+        if not np.all(user_ftc._qubit_value[ancilla_register_qubits] == 0):
+            error_msg = "ancilla qubit(s) are not back to 0 when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+        # check accumulator is back to 0
+        if not np.all(user_ftc._qubit_value[accumulator_qubit] == 0):
+            error_msg = "accumulator is not back to 0 when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+
+def assert_equal_Majorana_operation(
+        circuit: FastTestCircuit,
+        selection_register_qubits: list,
+        system_register_qubits: list,
+        accumulator_qubit: list,
+        control_qubits: list = [],
+        control_values: list = [],
+        ancilla_register_qubits: list = [],
+        verbose: bool = False,
+        msg=None):
+
+    user_ftc = copy.deepcopy(circuit)
+    size_selection_register = len(selection_register_qubits)
+    size_system_register = len(system_register_qubits)
+
+    # cvt all opearations to X
+    for i, gate in enumerate(user_ftc._gates):
+        if len(gate["target_qubit"]) == 1 and \
+                gate["target_qubit"][0] in system_register_qubits:
+            user_ftc._gates[i]["name"] = "x"
+
+    # execute ftc for all computational bases of selection_register
+    for l_ in range(size_system_register):
+        l_binary_rep = ("0" * size_selection_register +
+                        bin(l_)[2:])[-size_selection_register:]
+
+        # set all control qubits to active in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=control_qubits,
+            qubit_value=control_values
+        )
+        # initialize all system register qubits to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=system_register_qubits,
+            qubit_value=[0] * size_system_register
+        )
+        # initialize all the ancilla qubits to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=ancilla_register_qubits,
+            qubit_value=[0] * len(ancilla_register_qubits)
+        )
+        # initialize the accumulator to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=accumulator_qubit,
+            qubit_value=[0]
+        )
+        # initialize the selection register to l_binary_rep
+        user_ftc.set_qubit_value(
+            qubit_id=selection_register_qubits,
+            qubit_value=[int(i) for i in l_binary_rep]
+        )
+        user_ftc.execute_all_gates()
+
+        if verbose:
+            print(l_, user_ftc._qubit_value[system_register_qubits])
+
+        expected_qubit_value_of_system_register_qubits = \
+            np.array([0]*size_system_register)
+        expected_qubit_value_of_system_register_qubits[:l_+1] = 1
+
+        # check assert equal
+        if not np.all(expected_qubit_value_of_system_register_qubits
+                      == user_ftc._qubit_value[system_register_qubits]):
+            error_msg = "output from system register is not correct when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+        # check all ancillas are back to 0
+        if not np.all(user_ftc._qubit_value[ancilla_register_qubits] == 0):
+            error_msg = "ancilla qubit(s) are not back to 0 when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+        # check accumulator is back to 0
+        if not np.all(user_ftc._qubit_value[accumulator_qubit] == 0):
+            error_msg = "accumulator is not back to 0 when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)

--- a/quantestpy/unary_iteration.py
+++ b/quantestpy/unary_iteration.py
@@ -9,12 +9,12 @@ from quantestpy.exceptions import QuantestPyAssertionError
 ut_test_case = unittest.TestCase()
 
 
-def assert_equal_unary_iteration(
+def assert_equal_single_operation(
         circuit: FastTestCircuit,
-        control_qubits: list,
-        control_values: list,
         selection_register_qubits: list,
         system_register_qubits: list,
+        control_qubits: list = [],
+        control_values: list = [],
         ancilla_register_qubits: list = [],
         verbose: bool = False,
         msg=None):
@@ -57,7 +57,7 @@ def assert_equal_unary_iteration(
         user_ftc.execute_all_gates()
 
         if verbose:
-            print(user_ftc._qubit_value[system_register_qubits])
+            print(l_, user_ftc._qubit_value[system_register_qubits])
 
         expected_qubit_value_of_system_register_qubits = \
             np.array([0]*size_system_register)

--- a/quantestpy/unary_iteration.py
+++ b/quantestpy/unary_iteration.py
@@ -1,5 +1,5 @@
-import unittest
 import copy
+import unittest
 
 import numpy as np
 
@@ -15,16 +15,20 @@ def assert_equal_unary_iteration(
         control_values: list,
         selection_register_qubits: list,
         system_register_qubits: list,
-        operations: list,
+        ancilla_register_qubits: list = [],
+        verbose: bool = False,
         msg=None):
 
     user_ftc = copy.deepcopy(circuit)
     size_control = len(control_qubits)
     size_selection_register = len(selection_register_qubits)
     size_system_register = len(system_register_qubits)
-    other_qubits = [i for i in range(user_ftc._num_qubit) if i not in
-                    control_qubits + selection_register_qubits
-                    + system_register_qubits]
+
+    # cvt all opearations to X
+    for i, gate in enumerate(user_ftc._gates):
+        if len(gate["target_qubit"]) == 1 and \
+                gate["target_qubit"][0] in system_register_qubits:
+            user_ftc._gates[i]["name"] = "x"
 
     # first construct the correct circuit, i.e. no optimization circuit.
     ftc = FastTestCircuit(
@@ -34,16 +38,13 @@ def assert_equal_unary_iteration(
         l_binary_rep = ("0" * size_selection_register +
                         bin(l_)[2:])[-size_selection_register:]
 
-        for operation in operations[l_].split("*"):
-            ftc.add_gate(
-                {"name": operation,
-                 "target_qubit": [size_control + size_selection_register + l_],
-                 "control_qubit":
-                    [i for i in range(size_control+size_selection_register)],
-                 "control_value": control_values
-                 + [int(i) for i in l_binary_rep],
-                 "parameter": []}
-            )
+        ftc.add_gate(
+            {"name": "x",
+             "target_qubit": [size_control + size_selection_register + l_],
+             "control_qubit":
+                [i for i in range(size_control+size_selection_register)],
+             "control_value": control_values + [int(i) for i in l_binary_rep]}
+        )
 
     # execute ftc for all computational bases of selection_register
     for l_ in range(size_system_register):
@@ -79,10 +80,10 @@ def assert_equal_unary_iteration(
             qubit_id=system_register_qubits,
             qubit_value=[0] * size_system_register
         )
-        # initialize all the other qubits to 0 in user circuit
+        # initialize all the ancilla qubits to 0 in user circuit
         user_ftc.set_qubit_value(
-            qubit_id=other_qubits,
-            qubit_value=[0] * len(other_qubits)
+            qubit_id=ancilla_register_qubits,
+            qubit_value=[0] * len(ancilla_register_qubits)
         )
         user_ftc.set_qubit_value(
             qubit_id=selection_register_qubits,
@@ -90,10 +91,20 @@ def assert_equal_unary_iteration(
         )
         user_ftc.execute_all_gates()
 
-        #
+        if verbose:
+            print(user_ftc._qubit_value[system_register_qubits])
+
+        # check assert equal
         if not np.all(ftc._qubit_value[-size_system_register:]
                       == user_ftc._qubit_value[system_register_qubits]):
             error_msg = "output from system register is not correct when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)
+
+        # check all ancillas are back to 0
+        if not np.all(user_ftc._qubit_value[ancilla_register_qubits] == 0):
+            error_msg = "ancilla qubit(s) are not back to 0 when " \
                 + f"input to selection register is {l_binary_rep}."
             msg = ut_test_case._formatMessage(msg, error_msg)
             raise QuantestPyAssertionError(msg)

--- a/quantestpy/unary_iteration.py
+++ b/quantestpy/unary_iteration.py
@@ -1,0 +1,99 @@
+import unittest
+import copy
+
+import numpy as np
+
+from quantestpy import FastTestCircuit
+from quantestpy.exceptions import QuantestPyAssertionError
+
+ut_test_case = unittest.TestCase()
+
+
+def assert_equal_unary_iteration(
+        circuit: FastTestCircuit,
+        control_qubits: list,
+        control_values: list,
+        selection_register_qubits: list,
+        system_register_qubits: list,
+        operations: list,
+        msg=None):
+
+    user_ftc = copy.deepcopy(circuit)
+    size_control = len(control_qubits)
+    size_selection_register = len(selection_register_qubits)
+    size_system_register = len(system_register_qubits)
+    other_qubits = [i for i in range(user_ftc._num_qubit) if i not in
+                    control_qubits + selection_register_qubits
+                    + system_register_qubits]
+
+    # first construct the correct circuit, i.e. no optimization circuit.
+    ftc = FastTestCircuit(
+        size_control+size_selection_register+size_system_register)
+
+    for l_ in range(size_system_register):
+        l_binary_rep = ("0" * size_selection_register +
+                        bin(l_)[2:])[-size_selection_register:]
+
+        for operation in operations[l_].split("*"):
+            ftc.add_gate(
+                {"name": operation,
+                 "target_qubit": [size_control + size_selection_register + l_],
+                 "control_qubit":
+                    [i for i in range(size_control+size_selection_register)],
+                 "control_value": control_values
+                 + [int(i) for i in l_binary_rep],
+                 "parameter": []}
+            )
+
+    # execute ftc for all computational bases of selection_register
+    for l_ in range(size_system_register):
+        l_binary_rep = ("0" * size_selection_register +
+                        bin(l_)[2:])[-size_selection_register:]
+
+        # set all control qubits to active, i.e. control_values
+        ftc.set_qubit_value(
+            qubit_id=[i for i in range(size_control)],
+            qubit_value=control_values
+        )
+        # initialize all system register qubits to 0
+        ftc.set_qubit_value(
+            qubit_id=[i for i in range(
+                size_control+size_selection_register,
+                size_control+size_selection_register+size_system_register)],
+            qubit_value=[0] * size_system_register
+        )
+        ftc.set_qubit_value(
+            qubit_id=[i for i in range(size_control,
+                                       size_control+size_selection_register)],
+            qubit_value=[int(i) for i in l_binary_rep]
+        )
+        ftc.execute_all_gates()
+
+        # set all control qubits to active in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=control_qubits,
+            qubit_value=control_values
+        )
+        # initialize all system register qubits to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=system_register_qubits,
+            qubit_value=[0] * size_system_register
+        )
+        # initialize all the other qubits to 0 in user circuit
+        user_ftc.set_qubit_value(
+            qubit_id=other_qubits,
+            qubit_value=[0] * len(other_qubits)
+        )
+        user_ftc.set_qubit_value(
+            qubit_id=selection_register_qubits,
+            qubit_value=[int(i) for i in l_binary_rep]
+        )
+        user_ftc.execute_all_gates()
+
+        #
+        if not np.all(ftc._qubit_value[-size_system_register:]
+                      == user_ftc._qubit_value[system_register_qubits]):
+            error_msg = "output from system register is not correct when " \
+                + f"input to selection register is {l_binary_rep}."
+            msg = ut_test_case._formatMessage(msg, error_msg)
+            raise QuantestPyAssertionError(msg)


### PR DESCRIPTION
Below I implement the circuits of Fig.7, 8 and 9 in 1805.03662 and use the assert_equal_unary_iteration method in order to check the correctness of the implementation
```py
from quantestpy import FastTestCircuit
from quantestpy.unary_iteration import assert_equal_Majorana_operation, \
    assert_equal_single_operation, assert_equal_ranged_operation, \ 
    assert_check_control_values_for_operations_on_system_register
```

<details><summary>assert_equal_single_operation() for Fig7</summary>

```py
control_qubits = [0]
control_values = [1]
selection_register_qubits = [1, 2, 3, 4]
system_register_qubits = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
ancilla_register_qubits = [16, 17, 18, 19]
size_system_register = len(system_register_qubits)
size_selection_register = len(selection_register_qubits)

my_circ = FastTestCircuit(1+4+11+4)

my_circ.add_gate({"name": "x", "target_qubit": [16], "control_qubit": [0, 1],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [17], "control_qubit": [16, 2],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [17, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 0]})
# X_0
my_circ.add_gate({"name": "y", "target_qubit": [5], "control_qubit": [19],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18],
                  "control_value": [1]})
# X_1
my_circ.add_gate({"name": "y", "target_qubit": [6], "control_qubit": [19],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [17],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 0]})
# X_2
my_circ.add_gate({"name": "y", "target_qubit": [7], "control_qubit": [19],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18],
                  "control_value": [1]})
# X_3
my_circ.add_gate({"name": "y", "target_qubit": [8], "control_qubit": [19],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [17, 3],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [17], "control_qubit": [16],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [17, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 0]})
# X_4
my_circ.add_gate({"name": "y", "target_qubit": [9], "control_qubit": [19],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18],
                  "control_value": [1]})
# X_5
my_circ.add_gate({"name": "y", "target_qubit": [10], "control_qubit": [19],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [17],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 0]})
# X_6
my_circ.add_gate({"name": "y", "target_qubit": [11], "control_qubit": [19],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18],
                  "control_value": [1]})
# X_7
my_circ.add_gate({"name": "y", "target_qubit": [12], "control_qubit": [19],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [17, 3],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [17], "control_qubit": [16, 2],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [16], "control_qubit": [0],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [16, 3],
                  "control_value": [1, 0]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 0]})
# X_8
my_circ.add_gate({"name": "y", "target_qubit": [13], "control_qubit": [19],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18],
                  "control_value": [1]})
# X_9
my_circ.add_gate({"name": "y", "target_qubit": [14], "control_qubit": [19],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [19], "control_qubit": [18, 4],
                  "control_value": [1, 1]})

my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [16],
                  "control_value": [1]})
# X_10
my_circ.add_gate({"name": "y", "target_qubit": [15], "control_qubit": [18],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [18], "control_qubit": [16, 3],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [16], "control_qubit": [0, 1],
                  "control_value": [1, 1]})

assert_equal_single_operation(
    circuit=my_circ,
    control_qubits=control_qubits,
    control_values=control_values,
    selection_register_qubits=selection_register_qubits,
    system_register_qubits=system_register_qubits,
    ancilla_register_qubits=ancilla_register_qubits,
    verbose=True
)
0 [1 0 0 0 0 0 0 0 0 0 0]
1 [0 1 0 0 0 0 0 0 0 0 0]
2 [0 0 1 0 0 0 0 0 0 0 0]
3 [0 0 0 1 0 0 0 0 0 0 0]
4 [0 0 0 0 1 0 0 0 0 0 0]
5 [0 0 0 0 0 1 0 0 0 0 0]
6 [0 0 0 0 0 0 1 0 0 0 0]
7 [0 0 0 0 0 0 0 1 0 0 0]
8 [0 0 0 0 0 0 0 0 1 0 0]
9 [0 0 0 0 0 0 0 0 0 1 0]
10 [0 0 0 0 0 0 0 0 0 0 1]
```

</details>

<details><summary>assert_equal_ranged_operation() for Fig8</summary>

```py
control_qubits = [0]
control_values = [1]
selection_register_qubits = [1, 2, 3]
system_register_qubits = [4, 5, 6, 7, 8, 9, 10, 11]
ancilla_register_qubits = [12, 13, 14]
accumulator_qubit = [15]

my_circ = FastTestCircuit(1+3+8+3+1)
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [0],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [12], "control_qubit": [0, 1],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12, 2],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})

# G_0
my_circ.add_gate({"name": "z", "target_qubit": [4], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 1]})

# G_1
my_circ.add_gate({"name": "z", "target_qubit": [5], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})

# G_2
my_circ.add_gate({"name": "z", "target_qubit": [6], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12, 2],
                  "control_value": [1, 1]})

# G_3
my_circ.add_gate({"name": "z", "target_qubit": [7], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [12], "control_qubit": [0],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12, 2],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})

# G_4
my_circ.add_gate({"name": "z", "target_qubit": [8], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 1]})

# G_5
my_circ.add_gate({"name": "z", "target_qubit": [9], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})

# G_6
my_circ.add_gate({"name": "z", "target_qubit": [10], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})


my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12, 2],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [12], "control_qubit": [0, 1],
                  "control_value": [1, 1]})

assert_equal_ranged_operation(
    circuit=my_circ,
    control_qubits=control_qubits,
    control_values=control_values,
    selection_register_qubits=selection_register_qubits,
    system_register_qubits=system_register_qubits,
    ancilla_register_qubits=ancilla_register_qubits,
    accumulator_qubit=accumulator_qubit,
    verbose=True
)
0 [0 0 0 0 0 0 0 0]
1 [1 0 0 0 0 0 0 0]
2 [1 1 0 0 0 0 0 0]
3 [1 1 1 0 0 0 0 0]
4 [1 1 1 1 0 0 0 0]
5 [1 1 1 1 1 0 0 0]
6 [1 1 1 1 1 1 0 0]
7 [1 1 1 1 1 1 1 0]
```

</details>

<details><summary>assert_equal_Majorana_operation for Fig9</summary>

```py
control_qubits = [0]
control_values = [1]
selection_register_qubits = [1, 2, 3]
system_register_qubits = [4, 5, 6, 7, 8, 9, 10, 11]
ancilla_register_qubits = [12, 13, 14]
accumulator_qubit = [15]


my_circ = FastTestCircuit(1+3+8+3+1)
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [0],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [12], "control_qubit": [0, 1],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12, 2],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "y", "target_qubit": [4], "control_qubit": [14],
                  "control_value": [1]})

# G_0
my_circ.add_gate({"name": "z", "target_qubit": [4], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "y", "target_qubit": [5], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 1]})

# G_1
my_circ.add_gate({"name": "z", "target_qubit": [5], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "y", "target_qubit": [6], "control_qubit": [14],
                  "control_value": [1]})

# G_2
my_circ.add_gate({"name": "z", "target_qubit": [6], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "y", "target_qubit": [7], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12, 2],
                  "control_value": [1, 1]})

# G_3
my_circ.add_gate({"name": "z", "target_qubit": [7], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [12], "control_qubit": [0],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12, 2],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "y", "target_qubit": [8], "control_qubit": [14],
                  "control_value": [1]})

# G_4
my_circ.add_gate({"name": "z", "target_qubit": [8], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "y", "target_qubit": [9], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 1]})

# G_5
my_circ.add_gate({"name": "z", "target_qubit": [9], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 0]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "y", "target_qubit": [10], "control_qubit": [14],
                  "control_value": [1]})

# G_6
my_circ.add_gate({"name": "z", "target_qubit": [10], "control_qubit": [15],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13],
                  "control_value": [1]})
my_circ.add_gate({"name": "x", "target_qubit": [15], "control_qubit": [14],
                  "control_value": [1]})
my_circ.add_gate({"name": "y", "target_qubit": [11], "control_qubit": [14],
                  "control_value": [1]})

my_circ.add_gate({"name": "x", "target_qubit": [14], "control_qubit": [13, 3],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [13], "control_qubit": [12, 2],
                  "control_value": [1, 1]})
my_circ.add_gate({"name": "x", "target_qubit": [12], "control_qubit": [0, 1],
                  "control_value": [1, 1]})

assert_equal_Majorana_operation(
    circuit=my_circ,
    control_qubits=control_qubits,
    control_values=control_values,
    selection_register_qubits=selection_register_qubits,
    system_register_qubits=system_register_qubits,
    ancilla_register_qubits=ancilla_register_qubits,
    accumulator_qubit=accumulator_qubit,
    verbose=True
)
0 [1 0 0 0 0 0 0 0]
1 [1 1 0 0 0 0 0 0]
2 [1 1 1 0 0 0 0 0]
3 [1 1 1 1 0 0 0 0]
4 [1 1 1 1 1 0 0 0]
5 [1 1 1 1 1 1 0 0]
6 [1 1 1 1 1 1 1 0]
7 [1 1 1 1 1 1 1 1]
```

</details>


<details><summary>assert_check_control_values_for_operations_on_system_register() for Fig7</summary>

```py
In [3]: assert_check_control_values_for_operations_on_system_register(
   ...:     circuit=my_circ,
   ...:     control_qubits=control_qubits,
   ...:     control_values=control_values,
   ...:     selection_register_qubits=selection_register_qubits,
   ...:     system_register_qubits=system_register_qubits,
   ...:     ancilla_register_qubits=ancilla_register_qubits
   ...: )
   ...: 
l_binary rep.: 0000, control qubit values: [[1], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0001, control qubit values: [[0], [1], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0010, control qubit values: [[0], [0], [1], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0011, control qubit values: [[0], [0], [0], [1], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0100, control qubit values: [[0], [0], [0], [0], [1], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0101, control qubit values: [[0], [0], [0], [0], [0], [1], [0], [0], [0], [0], [0]]
l_binary rep.: 0110, control qubit values: [[0], [0], [0], [0], [0], [0], [1], [0], [0], [0], [0]]
l_binary rep.: 0111, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [1], [0], [0], [0]]
l_binary rep.: 1000, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [1], [0], [0]]
l_binary rep.: 1001, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [1], [0]]
l_binary rep.: 1010, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [1]]
l_binary rep.: 1011, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [1]]
l_binary rep.: 1100, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [1], [0], [0]]
l_binary rep.: 1101, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [1], [0]]
l_binary rep.: 1110, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [1]]
l_binary rep.: 1111, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [1]]

In [4]: assert_check_control_values_for_operations_on_system_register(
   ...:     circuit=my_circ,
   ...:     control_qubits=control_qubits,
   ...:     control_values=control_values,
   ...:     selection_register_qubits=selection_register_qubits,
   ...:     system_register_qubits=system_register_qubits,
   ...:     ancilla_register_qubits=ancilla_register_qubits,
   ...:     loop_over_all_selection_register_inputs=False
   ...: )
l_binary rep.: 0000, control qubit values: [[1], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0001, control qubit values: [[0], [1], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0010, control qubit values: [[0], [0], [1], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0011, control qubit values: [[0], [0], [0], [1], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0100, control qubit values: [[0], [0], [0], [0], [1], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 0101, control qubit values: [[0], [0], [0], [0], [0], [1], [0], [0], [0], [0], [0]]
l_binary rep.: 0110, control qubit values: [[0], [0], [0], [0], [0], [0], [1], [0], [0], [0], [0]]
l_binary rep.: 0111, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [1], [0], [0], [0]]
l_binary rep.: 1000, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [1], [0], [0]]
l_binary rep.: 1001, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [1], [0]]
l_binary rep.: 1010, control qubit values: [[0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [1]]
```

</details>

<details><summary>assert_check_control_values_for_operations_on_system_register() for Fig8</summary>

```py
In [6]: assert_check_control_values_for_operations_on_system_register(
   ...:     circuit=my_circ,
   ...:     control_qubits=control_qubits,
   ...:     control_values=control_values,
   ...:     selection_register_qubits=selection_register_qubits,
   ...:     system_register_qubits=system_register_qubits,
   ...:     ancilla_register_qubits=ancilla_register_qubits,
   ...:     accumulator_qubits=accumulator_qubit
   ...: )
l_binary rep.: 000, control qubit values: [[0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 001, control qubit values: [[1], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 010, control qubit values: [[1], [1], [0], [0], [0], [0], [0]]
l_binary rep.: 011, control qubit values: [[1], [1], [1], [0], [0], [0], [0]]
l_binary rep.: 100, control qubit values: [[1], [1], [1], [1], [0], [0], [0]]
l_binary rep.: 101, control qubit values: [[1], [1], [1], [1], [1], [0], [0]]
l_binary rep.: 110, control qubit values: [[1], [1], [1], [1], [1], [1], [0]]
l_binary rep.: 111, control qubit values: [[1], [1], [1], [1], [1], [1], [1]]
```

</details>

<details><summary>assert_check_control_values_for_operations_on_system_register() for Fig9</summary>

```py
In [8]: assert_check_control_values_for_operations_on_system_register(
   ...:     circuit=my_circ,
   ...:     control_qubits=control_qubits,
   ...:     control_values=control_values,
   ...:     selection_register_qubits=selection_register_qubits,
   ...:     system_register_qubits=system_register_qubits,
   ...:     ancilla_register_qubits=ancilla_register_qubits,
   ...:     accumulator_qubits=accumulator_qubit
   ...: )
l_binary rep.: 000, control qubit values: [[1], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 001, control qubit values: [[0], [1], [1], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 010, control qubit values: [[0], [1], [0], [1], [1], [0], [0], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 011, control qubit values: [[0], [1], [0], [1], [0], [1], [1], [0], [0], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 100, control qubit values: [[0], [1], [0], [1], [0], [1], [0], [1], [1], [0], [0], [0], [0], [0], [0]]
l_binary rep.: 101, control qubit values: [[0], [1], [0], [1], [0], [1], [0], [1], [0], [1], [1], [0], [0], [0], [0]]
l_binary rep.: 110, control qubit values: [[0], [1], [0], [1], [0], [1], [0], [1], [0], [1], [0], [1], [1], [0], [0]]
l_binary rep.: 111, control qubit values: [[0], [1], [0], [1], [0], [1], [0], [1], [0], [1], [0], [1], [0], [1], [1]]
```

</details>