### PR TITLE
Add docs for PauliCircuit class

### DIFF
--- a/doc/pauli_circuit.md
+++ b/doc/pauli_circuit.md
@@ -1,0 +1,30 @@
+# quantestpy.PauliCircuit
+
+## CLASS PauliCircuit(num_qubit)
+
+Creates a new circuit. In this circuit class a qubit is in a state either `|0>` or `|1>` with a global phase like a classical bit (i.e. no superpositions of these states) by limiting the gate operations to the Pauli and swap operations.
+
+Currently some of the assert methods accept only this circuit class as input circuits. For those who use their own circuit class, it is suggested to write a converter from it to `quantestpy.PauliCircuit`. This can be done easily by using the [add_gate](./pauli_circuit_add_gate.md) method.
+
+
+### Parameters
+#### num_qubit : int
+The number of qubits in the circuit.
+
+### Methods
+
+#### [add_gate](./pauli_circuit_add_gate.md)
+Adds a gate in the circuit.
+
+#### [set_qubit_value](./pauli_circuit_set_qubit_value.md)
+Sets the state of qubits either `|0>` or `|1>`.
+
+### Attributes
+None.
+
+### Examples
+Create a new circuit object with 100 qubits:
+```py
+import quantestpy as qp
+pc = qp.PauliCircuit(100)
+```

--- a/doc/pauli_circuit.md
+++ b/doc/pauli_circuit.md
@@ -17,7 +17,7 @@ The number of qubits in the circuit.
 Adds a gate in the circuit.
 
 #### [set_qubit_value](./pauli_circuit_set_qubit_value.md)
-Sets the state of qubits either `|0>` or `|1>`.
+Sets the state(s) of qubit(s) either `|0>` or `|1>`.
 
 ### Attributes
 None.

--- a/doc/pauli_circuit_add_gate.md
+++ b/doc/pauli_circuit_add_gate.md
@@ -1,0 +1,87 @@
+# quantestpy.PauliCircuit.add_gate
+
+## PauliCircuit.add_gate(gate)
+Adds a gate in the circuit.
+
+### Parameters
+
+#### gate : dict
+The gate to be added. The following key-values must be included:
+
+key | value | type of value
+--- | --- | ---
+"name" | gate's name | str
+"target_qubit" | target qubit(s) | list(int)
+"control_qubit" | control qubit(s) | list(int)
+"control_value" | control value(s) | list({0, 1})
+
+Users can always put multi-indices in "target_qubit", "control_qubit" and "control_value" for any gate as long as they are not out of range for the circuit size. An exception is "swap" gate, which restricts itself to two indices in "target_qubit". Controlled gates can be defined by specifying a gate name being performed on a single target qubit (such as "x") and giving a non-empty list to "control_qubit". By providing a non-empty list of 0 and 1 to "control_value", users can define the condition on the control qubit(s) for the gate to be applied on the target qubit(s). By definition, the length of "control_value" must be equal to that of "control_qubit".
+
+The following table lists the available gates:
+
+name | description | matrix representation
+--- | --- | --- | ---
+"x" | X gate | <img src="https://latex.codecogs.com/svg.image?\begin{bmatrix}&space;0&&space;1&space;\\&space;1&space;&&space;0&space;\end{bmatrix}" />
+"y" | Y gate | <img src="https://latex.codecogs.com/svg.image?\begin{bmatrix}&space;0&space;&&space;-i&space;\\&space;i&space;&&space;0&space;\end{bmatrix}" />
+"z" | Z gate | <img src="https://latex.codecogs.com/svg.image?\begin{bmatrix}&space;1&space;&&space;0&space;\\&space;0&space;&&space;-1&space;\end{bmatrix}" />
+"swap" | Swap gate | <img src="https://latex.codecogs.com/svg.image?\begin{bmatrix}&space;1&space;&&space;0&space;&&space;0&space;&&space;0&space;\\&space;0&space;&&space;0&space;&&space;1&space;&&space;0&space;\\&space;0&space;&&space;1&space;&&space;0&space;&&space;0&space;\\&space;0&space;&&space;0&space;&&space;0&space;&&space;1&space;\end{bmatrix}" />
+
+### Examples
+X gate:
+```py
+0  |0> ─[X]─
+
+1  |0> ─────
+
+pc = PauliCircuit(2)
+pc.add_gate({
+    "name": "x",
+    "target_qubit": [0],
+    "control_qubit": [],
+    "control_value": []
+})
+```
+Toffoli gate, conditional on the control qubits being set to 1:
+```py
+0  |0> ──■──
+         │
+1  |0> ──■──
+         │
+2  |0> ─[X]─
+
+pc = PauliCircuit(3)
+pc.add_gate({
+    "name": "x",
+    "target_qubit": [2],
+    "control_qubit": [0, 1],
+    "control_value": [1, 1]
+})
+```
+CZ gate, conditional on the control qubit being set to 0:
+```py
+0  |0> ──o──
+         │
+1  |0> ─[Z]─
+
+pc = PauliCircuit(2)
+pc.add_gate({
+    "name": "z",
+    "target_qubit": [1],
+    "control_qubit": [0],
+    "control_value": [0]
+})
+```
+YY gate:
+```py
+0  |0> ─[Y]─
+
+1  |0> ─[Y]─
+
+pc = PauliCircuit(2)
+pc.add_gate({
+    "name": "y",
+    "target_qubit": [0, 1],
+    "control_qubit": [],
+    "control_value": []
+})
+```

--- a/doc/pauli_circuit_add_gate.md
+++ b/doc/pauli_circuit_add_gate.md
@@ -20,7 +20,7 @@ Users can always put multi-indices in "target_qubit", "control_qubit" and "contr
 The following table lists the available gates:
 
 name | description | matrix representation
---- | --- | --- | ---
+--- | --- | ---
 "x" | X gate | <img src="https://latex.codecogs.com/svg.image?\begin{bmatrix}&space;0&&space;1&space;\\&space;1&space;&&space;0&space;\end{bmatrix}" />
 "y" | Y gate | <img src="https://latex.codecogs.com/svg.image?\begin{bmatrix}&space;0&space;&&space;-i&space;\\&space;i&space;&&space;0&space;\end{bmatrix}" />
 "z" | Z gate | <img src="https://latex.codecogs.com/svg.image?\begin{bmatrix}&space;1&space;&&space;0&space;\\&space;0&space;&&space;-1&space;\end{bmatrix}" />

--- a/doc/pauli_circuit_set_qubit_value.md
+++ b/doc/pauli_circuit_set_qubit_value.md
@@ -1,0 +1,31 @@
+# quantestpy.PauliCircuit.set_qubit_value
+
+## PauliCircuit.set_qubit_value(qubit_idx, qubit_val)
+Sets the state(s) of qubit(s) either `|0>` or `|1>`.
+
+The default is all the qubits being initialized to `|0>`.
+
+### Parameters
+
+#### qubit_idx : list(int)
+qubit index(indices)
+
+#### qubit_val : list(int)
+qubit value(s), either 0 or 1. The length of `qubit_val` must be equal to that of `qubit_idx`.
+
+### Examples
+Set the state(s) of only the qubits 0 and 1 in `|1>` while the others in `|0>`:
+```py
+0  |1> ─
+
+1  |1> ─
+
+2  |0> ─
+
+3  |0> ─
+
+4  |0> ─
+
+pc = PauliCircuit(5)
+pc.set_qubit_value([0, 1], [1, 1])
+```

--- a/doc/pauli_circuit_set_qubit_value.md
+++ b/doc/pauli_circuit_set_qubit_value.md
@@ -14,7 +14,7 @@ qubit index(indices)
 qubit value(s), either 0 or 1. The length of `qubit_val` must be equal to that of `qubit_idx`.
 
 ### Examples
-Set the state(s) of only the qubits 0 and 1 in `|1>` while the others in `|0>`:
+Set the states of only the qubits 0 and 1 in `|1>` while the others in `|0>`:
 ```py
 0  |1> ─
 


### PR DESCRIPTION
I add a doc to explain the PauliCircuit class:
https://github.com/QuantestPy/quantestpy/blob/issue156/doc/pauli_circuit.md