### PR TITLE
Add the draw method in PauliCircuit

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -33,8 +33,7 @@ jobs:
         run: |
           python3 -m unittest discover -v ./test/
           python3 -m unittest discover -v ./test/assertion/*
-          python3 -m unittest discover -v ./test/simulator/pauli_circuit/
-          python3 -m unittest discover -v ./test/simulator/circuit_drawer/
+          python3 -m unittest discover -v ./test/simulator/*
 
   test_with_qiskit:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -33,7 +33,8 @@ jobs:
         run: |
           python3 -m unittest discover -v ./test/
           python3 -m unittest discover -v ./test/assertion/*
-          python3 -m unittest discover -v ./test/simulator/*
+          python3 -m unittest discover -v ./test/simulator/pauli_circuit/
+          python3 -m unittest discover -v ./test/simulator/circuit_drawer/
 
   test_with_qiskit:
     runs-on: ubuntu-latest

--- a/doc/pauli_circuit.md
+++ b/doc/pauli_circuit.md
@@ -19,6 +19,9 @@ Adds a gate in the circuit.
 #### [set_qubit_value](./pauli_circuit_set_qubit_value.md)
 Sets the state(s) of qubit(s) either `|0>` or `|1>`.
 
+#### [draw](./pauli_circuit_draw.md)
+Draws the circuit.
+
 ### Attributes
 None.
 

--- a/doc/pauli_circuit_draw.md
+++ b/doc/pauli_circuit_draw.md
@@ -7,55 +7,17 @@ Draws the circuit.
 ```py
 In [1]: from quantestpy import PauliCircuit
 
-In [2]: pc = PauliCircuit(13)
-   ...: pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2], "control_value": [1, 0]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [2, 3], "target_qubit": [4], "control_value": [1, 0]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [4, 5], "target_qubit": [6], "control_value": [1, 0]})
-   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [7], "control_value": [1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [4], "target_qubit": [6], "control_value": [1]})
-   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [8], "control_value": [1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [4, 5], "target_qubit": [6], "control_value": [1, 1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [2], "target_qubit": [4], "control_value": [1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [4, 5], "target_qubit": [6], "control_value": [1, 0]})
-   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [9], "control_value": [1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [4], "target_qubit": [6], "control_value": [1]})
-   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [10], "control_value": [1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [4, 5], "target_qubit": [6], "control_value": [1, 1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [2, 3], "target_qubit": [4], "control_value": [1, 1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [0], "target_qubit": [2], "control_value": [1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [2, 5], "target_qubit": [6], "control_value": [1, 0]})
-   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [11], "control_value": [1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [2], "target_qubit": [6], "control_value": [1]})
-   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [12], "control_value": [1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [2, 5], "target_qubit": [6], "control_value": [1, 1]})
-   ...: pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2], "control_value": [1, 1]})
+In [2]: pc = PauliCircuit(3)
+   ...: pc.add_gate({"name": "x", "control_qubit": [], "target_qubit": [0], "control_value": []})
+   ...: pc.add_gate({"name": "z", "control_qubit": [0], "target_qubit": [2], "control_value": [1]})
 
 In [3]: pc.draw()
 Out[3]:
-0   |0> ──■───────────────────────────────────────────────────────■───────────────────────■──
-          │                                                       │                       │
-1   |0> ──o───────────────────────────────────────────────────────┼───────────────────────■──
-          │                                                       │                       │
-2   |0> ─[X]──■───────────────────────■───────────────────────■──[X]──■───────■───────■──[X]─
-              │                       │                       │       │       │       │
-3   |0> ──────o───────────────────────┼───────────────────────■───────┼───────┼───────┼──────
-              │                       │                       │       │       │       │
-4   |0> ─────[X]──■───────■───────■──[X]──■───────■───────■──[X]──────┼───────┼───────┼──────
-                  │       │       │       │       │       │           │       │       │
-5   |0> ──────────o───────┼───────■───────o───────┼───────■───────────o───────┼───────■──────
-                  │       │       │       │       │       │           │       │       │
-6   |0> ─────────[X]──■──[X]──■──[X]─────[X]──■──[X]──■──[X]─────────[X]──■──[X]──■──[X]─────
-                      │       │               │       │                   │       │
-7   |0> ─────────────[Y]──────┼───────────────┼───────┼───────────────────┼───────┼──────────
-                              │               │       │                   │       │
-8   |0> ─────────────────────[Y]──────────────┼───────┼───────────────────┼───────┼──────────
-                                              │       │                   │       │
-9   |0> ─────────────────────────────────────[Y]──────┼───────────────────┼───────┼──────────
-                                                      │                   │       │
-10  |0> ─────────────────────────────────────────────[Y]──────────────────┼───────┼──────────
-                                                                          │       │
-11  |0> ─────────────────────────────────────────────────────────────────[Y]──────┼──────────
-                                                                                  │
-12  |0> ─────────────────────────────────────────────────────────────────────────[Y]─────────
+0  |0> ─[X]──■──
+             │
+1  |0> ──────┼──
+             │
+2  |0> ─────[Z]─
 
+In [4]:
 ```

--- a/doc/pauli_circuit_draw.md
+++ b/doc/pauli_circuit_draw.md
@@ -1,0 +1,61 @@
+# quantestpy.PauliCircuit.draw
+
+## PauliCircuit.draw()
+Draws the circuit.
+
+### Examples
+```py
+In [1]: from quantestpy import PauliCircuit
+
+In [2]: pc = PauliCircuit(13)
+   ...: pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2], "control_value": [1, 0]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [2, 3], "target_qubit": [4], "control_value": [1, 0]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [4, 5], "target_qubit": [6], "control_value": [1, 0]})
+   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [7], "control_value": [1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [4], "target_qubit": [6], "control_value": [1]})
+   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [8], "control_value": [1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [4, 5], "target_qubit": [6], "control_value": [1, 1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [2], "target_qubit": [4], "control_value": [1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [4, 5], "target_qubit": [6], "control_value": [1, 0]})
+   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [9], "control_value": [1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [4], "target_qubit": [6], "control_value": [1]})
+   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [10], "control_value": [1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [4, 5], "target_qubit": [6], "control_value": [1, 1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [2, 3], "target_qubit": [4], "control_value": [1, 1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [0], "target_qubit": [2], "control_value": [1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [2, 5], "target_qubit": [6], "control_value": [1, 0]})
+   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [11], "control_value": [1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [2], "target_qubit": [6], "control_value": [1]})
+   ...: pc.add_gate({"name": "y", "control_qubit": [6], "target_qubit": [12], "control_value": [1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [2, 5], "target_qubit": [6], "control_value": [1, 1]})
+   ...: pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2], "control_value": [1, 1]})
+
+In [3]: pc.draw()
+Out[3]:
+0   |0> ──■───────────────────────────────────────────────────────■───────────────────────■──
+          │                                                       │                       │
+1   |0> ──o───────────────────────────────────────────────────────┼───────────────────────■──
+          │                                                       │                       │
+2   |0> ─[X]──■───────────────────────■───────────────────────■──[X]──■───────■───────■──[X]─
+              │                       │                       │       │       │       │
+3   |0> ──────o───────────────────────┼───────────────────────■───────┼───────┼───────┼──────
+              │                       │                       │       │       │       │
+4   |0> ─────[X]──■───────■───────■──[X]──■───────■───────■──[X]──────┼───────┼───────┼──────
+                  │       │       │       │       │       │           │       │       │
+5   |0> ──────────o───────┼───────■───────o───────┼───────■───────────o───────┼───────■──────
+                  │       │       │       │       │       │           │       │       │
+6   |0> ─────────[X]──■──[X]──■──[X]─────[X]──■──[X]──■──[X]─────────[X]──■──[X]──■──[X]─────
+                      │       │               │       │                   │       │
+7   |0> ─────────────[Y]──────┼───────────────┼───────┼───────────────────┼───────┼──────────
+                              │               │       │                   │       │
+8   |0> ─────────────────────[Y]──────────────┼───────┼───────────────────┼───────┼──────────
+                                              │       │                   │       │
+9   |0> ─────────────────────────────────────[Y]──────┼───────────────────┼───────┼──────────
+                                                      │                   │       │
+10  |0> ─────────────────────────────────────────────[Y]──────────────────┼───────┼──────────
+                                                                          │       │
+11  |0> ─────────────────────────────────────────────────────────────────[Y]──────┼──────────
+                                                                                  │
+12  |0> ─────────────────────────────────────────────────────────────────────────[Y]─────────
+
+```

--- a/quantestpy/simulator/circuit_drawer.py
+++ b/quantestpy/simulator/circuit_drawer.py
@@ -1,0 +1,387 @@
+import copy
+
+from quantestpy.exceptions import QuantestPyError
+from quantestpy.simulator.pauli_circuit import PauliCircuit
+
+
+class CircuitDrawer:
+
+    def __init__(self, pc: PauliCircuit):
+        self._pc = copy.deepcopy(pc)
+        self._qubit_value = pc._qubit_value.copy()
+        self._qubit_phase = pc._qubit_phase.copy()
+
+        self._color_code_line_1 = ""
+        self._color_code_line_0 = ""
+
+        self._color_code_tgt = ""
+        self._color_code_ctrl = ""
+        self._color_code_cross = ""
+        self._color_code_wire = ""
+
+        self._num_qubit = self._pc._num_qubit
+        self._num_line = 2*self._num_qubit - 1
+        self._qubit_id_to_line_id = {qubit_id: qubit_id * 2
+                                     for qubit_id in range(self._num_qubit)}
+        self._line_id_to_qubit_id \
+            = {line_id: line_id // 2
+               for line_id in range(self._num_line) if line_id % 2 == 0}
+        self._line_id_to_text \
+            = {line_id: "" for line_id in range(self._num_line)}
+        self._qubit_id_to_color_code \
+            = {qubit_id: "" for qubit_id in range(self._num_qubit)}
+        self._qubit_id_to_reg_name \
+            = {qubit_id: "" for qubit_id in range(self._num_qubit)}
+
+        self._occupied_line_id = list()
+
+    @property
+    def line_id_to_text(self):
+        return self._line_id_to_text
+
+    @staticmethod
+    def get_color_code(color: str) -> str:
+        if color == "black":
+            return "\033[30m"
+        elif color == "red":
+            return "\033[31m"
+        elif color == "green":
+            return "\033[32m"
+        elif color == "yellow":
+            return "\033[33m"
+        elif color == "blue":
+            return "\033[34m"
+        elif color == "purple":
+            return "\033[35m"
+        elif color == "cyan":
+            return "\033[36m"
+        elif color == "white":
+            return "\033[37m"
+        elif color == "":
+            return ""
+        else:
+            raise QuantestPyError(f"{color} is invalid color.")
+
+    def set_color_to_reg(self, color_to_reg: dict) -> None:
+        for color, reg in color_to_reg.items():
+            self._pc._assert_is_correct_reg(reg)
+            for qubit_id in reg:
+                self._qubit_id_to_color_code[qubit_id] = self.get_color_code(
+                    color)
+
+    def set_name_to_reg(self, name_to_reg: dict) -> None:
+        for name, reg in name_to_reg.items():
+            self._pc._assert_is_correct_reg(reg)
+            for qubit_id in reg:
+                self._qubit_id_to_reg_name[qubit_id] = name
+
+    def reset_all(self,) -> None:
+        self._line_id_to_text \
+            = {line_id: "" for line_id in range(self._num_line)}
+        self._pc._qubit_value = self._qubit_value.copy()
+        self._pc._qubit_phase = self._qubit_phase.copy()
+
+    def get_color_code_line(self, qubit_val: int) -> str:
+        return self._color_code_line_1 if qubit_val == 1 else \
+            self._color_code_line_0
+
+    @staticmethod
+    def get_line(qubit_val: int, length: int = 3, color_code: str = "") -> str:
+        _ = qubit_val  # unused
+        return color_code + "─" * length + "\033[0m"
+
+    @staticmethod
+    def get_cross_line(qubit_val: int,
+                       color_code_cross: str = "",
+                       color_code_line: str = "") -> str:
+        _ = qubit_val  # unused
+        return color_code_line + "─" + "\033[0m" \
+            + color_code_cross + "┼" + "\033[0m" \
+            + color_code_line + "─" + "\033[0m"
+
+    @staticmethod
+    def get_wire(color_code: str = ""):
+        return color_code + " │ " + "\033[0m"
+
+    @staticmethod
+    def get_space(length: int = 3) -> str:
+        return " " * length
+
+    @staticmethod
+    def get_tgt(name: str, qubit_val: int, color_code: str = "") -> str:
+        _ = qubit_val  # unused
+        if name == "x":
+            obj = "[X]"
+        elif name == "y":
+            obj = "[Y]"
+        elif name == "z":
+            obj = "[Z]"
+        elif name == "swap":
+            obj = " X "
+        else:
+            raise QuantestPyError(
+                f"{name} is invalid input."
+            )
+        return color_code + obj + "\033[0m"
+
+    @staticmethod
+    def get_ctrl(ctrl_val: int,
+                 qubit_val: int,
+                 color_code_ctrl: str = "",
+                 color_code_line: str = "") -> str:
+        _ = qubit_val  # unused
+        obj = "■" if ctrl_val == 1 else "o"
+        return color_code_line + "─" + "\033[0m" \
+            + color_code_ctrl + obj + "\033[0m" \
+            + color_code_line + "─" + "\033[0m"
+
+    @staticmethod
+    def get_init_state(qubit_val: int, color_code: str = "") -> str:
+        obj = "|1>" if qubit_val == 1 else "|0>"
+        return color_code + obj + "\033[0m"
+
+    @staticmethod
+    def get_inter_line_id(id_a: int, id_b: int) -> list:
+        id_max, id_min = max(id_a, id_b), min(id_a, id_b)
+        return [id_ for id_ in range(id_max) if id_ < id_max and id_ > id_min]
+
+    def draw_qubit_indentifer(self) -> None:
+        """Draws a qubit identifer
+
+        ::
+        '0 reg1'
+
+        '1     '
+        """
+        reg_name_max_length = 0
+        for reg_name in self._qubit_id_to_reg_name.values():
+            if len(reg_name) > reg_name_max_length:
+                reg_name_max_length = len(reg_name)
+
+        id_max_length = len(str(self._num_qubit-1))
+        for line_id in range(self._num_line):
+            if line_id in self._line_id_to_qubit_id.keys():
+                qubit_id = self._line_id_to_qubit_id[line_id]
+                reg_name = self._qubit_id_to_reg_name[qubit_id]
+                self._line_id_to_text[line_id] += \
+                    self._qubit_id_to_color_code[qubit_id] \
+                    + str(qubit_id) \
+                    + self.get_space(id_max_length+1-len(str(qubit_id))) \
+                    + reg_name \
+                    + "\033[0m" \
+                    + self.get_space(reg_name_max_length-len(reg_name))
+            else:
+                self._line_id_to_text[line_id] += \
+                    self.get_space(id_max_length+1+reg_name_max_length)
+
+    def draw_init_vector(self) -> None:
+        """Draws initial state vectors.
+
+        ::
+        |1>
+
+        |0>
+        """
+        for line_id in range(self._num_line):
+            if line_id in self._line_id_to_qubit_id.keys():
+                qubit_id = self._line_id_to_qubit_id[line_id]
+                qubit_val = self._pc._qubit_value[qubit_id]
+                self._line_id_to_text[line_id] += \
+                    self.get_init_state(
+                        qubit_val=qubit_val,
+                        color_code=self.get_color_code_line(qubit_val))
+            else:
+                self._line_id_to_text[line_id] += self.get_space(length=3)
+
+    def draw_space(self,) -> None:
+        """Draws spaces.
+
+        ::
+        ' '
+        """
+        for line_id in range(self._num_line):
+            self._line_id_to_text[line_id] += self.get_space(length=1)
+
+    def draw_line(self) -> None:
+        """Draws lines.
+
+        ::
+        ─
+
+        ─
+
+        ─
+        """
+        for line_id in range(self._num_line):
+            if line_id in self._line_id_to_qubit_id.keys():
+                qubit_id = self._line_id_to_qubit_id[line_id]
+                qubit_val = self._pc._qubit_value[qubit_id]
+                cc = self.get_color_code_line(qubit_val)
+                self._line_id_to_text[line_id] += \
+                    self.get_line(qubit_val=qubit_val, length=1, color_code=cc)
+            else:
+                self._line_id_to_text[line_id] += self.get_space(length=1)
+
+    def draw_tgt(self, gate_id: int) -> None:
+        """Draws target objs in a gate.
+
+        ::
+        [X]
+
+        [X]
+        """
+        gate = self._pc._gates[gate_id]
+        for tg_qubit_id in gate["target_qubit"]:
+            line_id = self._qubit_id_to_line_id[tg_qubit_id]
+            qubit_val = self._pc._qubit_value[tg_qubit_id]
+            self._line_id_to_text[line_id] += \
+                self.get_tgt(
+                    name=gate["name"],
+                    qubit_val=qubit_val,
+                    color_code=self._color_code_tgt)
+            self._occupied_line_id.append(line_id)
+
+    def draw_ctrl(self, gate_id: int) -> None:
+        """Draws ctrl objs in a gate.
+
+        ::
+        ─■─
+
+        ─■─
+        """
+        gate = self._pc._gates[gate_id]
+        for ctrl_qubit_id, ctrl_val \
+                in zip(gate["control_qubit"], gate["control_value"]):
+            line_id = self._qubit_id_to_line_id[ctrl_qubit_id]
+            qubit_val = self._pc._qubit_value[ctrl_qubit_id]
+            cc_ctrl = self._color_code_ctrl if \
+                len(self._color_code_ctrl) > 0 \
+                else self.get_color_code_line(qubit_val)
+            cc_line = self.get_color_code_line(qubit_val)
+            self._line_id_to_text[line_id] += self.get_ctrl(
+                ctrl_val=ctrl_val,
+                qubit_val=qubit_val,
+                color_code_ctrl=cc_ctrl,
+                color_code_line=cc_line
+            )
+            self._occupied_line_id.append(line_id)
+
+    def draw_wire(self, gate_id: int) -> None:
+        """Draws wire objs between tgt and ctrl objs in a gate.
+
+        ::
+         │
+         ┼
+         │
+        """
+        gate = self._pc._gates[gate_id]
+        inter_line_id = list()
+        for ctrl_qubit_id in gate["control_qubit"]:
+            ctrl_line_id = self._qubit_id_to_line_id[ctrl_qubit_id]
+            for tg_qubit_id in gate["target_qubit"]:
+                tg_line_id = self._qubit_id_to_line_id[tg_qubit_id]
+                inter_line_id += self.get_inter_line_id(tg_line_id,
+                                                        ctrl_line_id)
+
+        for line_id in set(inter_line_id):
+            # only when not occupied yet
+            if line_id not in self._occupied_line_id:
+                if line_id in self._line_id_to_qubit_id.keys():  # qubit
+                    qubit_id = self._line_id_to_qubit_id[line_id]
+                    qubit_val = self._pc._qubit_value[qubit_id]
+                    cc_cross = self._color_code_cross
+                    cc_line = self.get_color_code_line(qubit_val)
+                    self._line_id_to_text[line_id] += self.get_cross_line(
+                        qubit_val=qubit_val,
+                        color_code_cross=cc_cross,
+                        color_code_line=cc_line
+                    )
+                else:  # inter horizontal space
+                    self._line_id_to_text[line_id] += \
+                        self.get_wire(self._color_code_wire)
+                self._occupied_line_id.append(line_id)
+
+    def draw_rest(self, gate_id: int) -> None:
+        """Draws objs to fill the holes.
+
+        ::
+        '   '
+
+        """
+        for line_id in range(self._num_line):
+            # only when not occupied yet
+            if line_id not in self._occupied_line_id:
+                if line_id in self._line_id_to_qubit_id.keys():  # qubit
+                    qubit_id = self._line_id_to_qubit_id[line_id]
+                    qubit_val = self._pc._qubit_value[qubit_id]
+                    cc_line = self.get_color_code_line(qubit_val)
+                    self._line_id_to_text[line_id] += \
+                        self.get_line(qubit_val=qubit_val, color_code=cc_line)
+                else:  # inter horizontal space
+                    self._line_id_to_text[line_id] += self.get_space()
+                self._occupied_line_id.append(line_id)
+
+    def draw_one_gate(self, gate_id: int) -> None:
+        """Draws objs for one gate operation.
+
+        ::
+        ─■─
+         │
+        ─┼─
+         │
+        ─o─
+         │
+        [X]
+
+        ───
+        """
+        self._occupied_line_id = list()
+        self.draw_tgt(gate_id)
+        self.draw_ctrl(gate_id)
+        self.draw_wire(gate_id)
+        self.draw_rest(gate_id)
+
+        if len(self._occupied_line_id) != self._num_line:
+            raise QuantestPyError("Unexpected error. Please report.")
+
+    def draw_circuit(self) -> None:
+        """Draw all objs for the circuit
+
+        ::
+        0  |1> ──■──────[X]─
+                 │       │
+        1  |0> ──┼───────┼──
+                 │       │
+        2  |1> ──o───■───■──
+                 │   │   │
+        3  |1> ─[X]──o───┼──
+                     │   │
+        4  |1> ─────[X]──■──
+        """
+        self.draw_qubit_indentifer()
+        self.draw_space()
+        self.draw_init_vector()
+        self.draw_space()
+        self.draw_line()
+
+        for i in range(len(self._pc._gates)):
+            self.draw_one_gate(i)
+            self._pc._execute_i_th_gate(i)
+            self.draw_line()
+
+    def create_single_string(self) -> str:
+        return "\n".join(list(self.line_id_to_text.values()))
+
+    def __repr__(self) -> str:
+        return self.create_single_string()
+
+    def __str__(self) -> str:
+        return self.create_single_string()
+
+
+def draw_circuit(circuit: PauliCircuit) -> CircuitDrawer:
+    """This is the user interface."""
+    PauliCircuit._assert_is_pauli_circuit(circuit)
+    cd = CircuitDrawer(circuit)
+    cd.draw_circuit()
+    return cd

--- a/quantestpy/simulator/circuit_drawer.py
+++ b/quantestpy/simulator/circuit_drawer.py
@@ -8,8 +8,8 @@ class CircuitDrawer:
 
     def __init__(self, pc: PauliCircuit):
         self._pc = copy.deepcopy(pc)
-        self._qubit_value = pc._qubit_value.copy()
-        self._qubit_phase = pc._qubit_phase.copy()
+        self._qubit_value = pc.qubit_value
+        self._qubit_phase = pc.qubit_phase
 
         self._color_code_line_1 = ""
         self._color_code_line_0 = ""
@@ -78,8 +78,8 @@ class CircuitDrawer:
     def reset_all(self,) -> None:
         self._line_id_to_text \
             = {line_id: "" for line_id in range(self._num_line)}
-        self._pc._qubit_value = self._qubit_value.copy()
-        self._pc._qubit_phase = self._qubit_phase.copy()
+        self._pc.qubit_value = self._qubit_value.copy()
+        self._pc.qubit_phase = self._qubit_phase.copy()
 
     def get_color_code_line(self, qubit_val: int) -> str:
         return self._color_code_line_1 if qubit_val == 1 else \
@@ -185,7 +185,7 @@ class CircuitDrawer:
         for line_id in range(self._num_line):
             if line_id in self._line_id_to_qubit_id.keys():
                 qubit_id = self._line_id_to_qubit_id[line_id]
-                qubit_val = self._pc._qubit_value[qubit_id]
+                qubit_val = self._pc.qubit_value[qubit_id]
                 self._line_id_to_text[line_id] += \
                     self.get_init_state(
                         qubit_val=qubit_val,
@@ -215,7 +215,7 @@ class CircuitDrawer:
         for line_id in range(self._num_line):
             if line_id in self._line_id_to_qubit_id.keys():
                 qubit_id = self._line_id_to_qubit_id[line_id]
-                qubit_val = self._pc._qubit_value[qubit_id]
+                qubit_val = self._pc.qubit_value[qubit_id]
                 cc = self.get_color_code_line(qubit_val)
                 self._line_id_to_text[line_id] += \
                     self.get_line(qubit_val=qubit_val, length=1, color_code=cc)
@@ -233,7 +233,7 @@ class CircuitDrawer:
         gate = self._pc._gates[gate_id]
         for tg_qubit_id in gate["target_qubit"]:
             line_id = self._qubit_id_to_line_id[tg_qubit_id]
-            qubit_val = self._pc._qubit_value[tg_qubit_id]
+            qubit_val = self._pc.qubit_value[tg_qubit_id]
             self._line_id_to_text[line_id] += \
                 self.get_tgt(
                     name=gate["name"],
@@ -253,7 +253,7 @@ class CircuitDrawer:
         for ctrl_qubit_id, ctrl_val \
                 in zip(gate["control_qubit"], gate["control_value"]):
             line_id = self._qubit_id_to_line_id[ctrl_qubit_id]
-            qubit_val = self._pc._qubit_value[ctrl_qubit_id]
+            qubit_val = self._pc.qubit_value[ctrl_qubit_id]
             cc_ctrl = self._color_code_ctrl if \
                 len(self._color_code_ctrl) > 0 \
                 else self.get_color_code_line(qubit_val)
@@ -288,7 +288,7 @@ class CircuitDrawer:
             if line_id not in self._occupied_line_id:
                 if line_id in self._line_id_to_qubit_id.keys():  # qubit
                     qubit_id = self._line_id_to_qubit_id[line_id]
-                    qubit_val = self._pc._qubit_value[qubit_id]
+                    qubit_val = self._pc.qubit_value[qubit_id]
                     cc_cross = self._color_code_cross
                     cc_line = self.get_color_code_line(qubit_val)
                     self._line_id_to_text[line_id] += self.get_cross_line(
@@ -314,7 +314,7 @@ class CircuitDrawer:
             if line_id not in self._occupied_line_id:
                 if line_id in self._line_id_to_qubit_id.keys():  # qubit
                     qubit_id = self._line_id_to_qubit_id[line_id]
-                    qubit_val = self._pc._qubit_value[qubit_id]
+                    qubit_val = self._pc.qubit_value[qubit_id]
                     cc_line = self.get_color_code_line(qubit_val)
                     self._line_id_to_text[line_id] += \
                         self.get_line(qubit_val=qubit_val, color_code=cc_line)

--- a/quantestpy/simulator/circuit_drawer.py
+++ b/quantestpy/simulator/circuit_drawer.py
@@ -117,7 +117,7 @@ class CircuitDrawer:
         elif name == "z":
             obj = "[Z]"
         elif name == "swap":
-            obj = " X "
+            obj = "SWP"
         else:
             raise QuantestPyError(
                 f"{name} is invalid input."
@@ -145,7 +145,7 @@ class CircuitDrawer:
         id_max, id_min = max(id_a, id_b), min(id_a, id_b)
         return [id_ for id_ in range(id_max) if id_ < id_max and id_ > id_min]
 
-    def draw_qubit_indentifer(self) -> None:
+    def draw_qubit_indentifier(self) -> None:
         """Draws a qubit identifer
 
         ::
@@ -308,6 +308,7 @@ class CircuitDrawer:
         '   '
 
         """
+        _ = gate_id  # unused
         for line_id in range(self._num_line):
             # only when not occupied yet
             if line_id not in self._occupied_line_id:
@@ -358,7 +359,7 @@ class CircuitDrawer:
                      │   │
         4  |1> ─────[X]──■──
         """
-        self.draw_qubit_indentifer()
+        self.draw_qubit_indentifier()
         self.draw_space()
         self.draw_init_vector()
         self.draw_space()

--- a/quantestpy/simulator/pauli_circuit.py
+++ b/quantestpy/simulator/pauli_circuit.py
@@ -18,6 +18,22 @@ class PauliCircuit(TestCircuit):
         self._qubit_value = np.array([0 for _ in range(num_qubit)])
         self._qubit_phase = np.array([0. for _ in range(num_qubit)])
 
+    @property
+    def qubit_value(self,):
+        return self._qubit_value
+
+    @property
+    def qubit_phase(self,):
+        return self._qubit_phase
+
+    @qubit_value.setter
+    def qubit_value(self, value):
+        self._qubit_value = value
+
+    @qubit_phase.setter
+    def qubit_phase(self, value):
+        self._qubit_phase = value
+
     def add_gate(self, gate: dict) -> None:
         if not isinstance(gate, dict):
             raise QuantestPyTestCircuitError(

--- a/quantestpy/simulator/pauli_circuit.py
+++ b/quantestpy/simulator/pauli_circuit.py
@@ -136,3 +136,8 @@ class PauliCircuit(TestCircuit):
     def _execute_all_gates(self,) -> None:
         for i in range(len(self._gates)):
             self._execute_i_th_gate(i)
+
+    def draw(self,):
+        from quantestpy.simulator.circuit_drawer import draw_circuit
+
+        return draw_circuit(self)

--- a/test/simulator/circuit_drawer/test_draw_circuit.py
+++ b/test/simulator/circuit_drawer/test_draw_circuit.py
@@ -1,0 +1,68 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawCircuit(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_circuit
+    ..
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.001s
+
+    OK
+    $
+    """
+
+    def test_regular(self,):
+        pc = PauliCircuit(5)
+        pc.set_qubit_value(qubit_idx=[0], qubit_val=[1])
+        pc.add_gate({"name": "x", "control_qubit": [0, 2], "target_qubit": [3],
+                     "control_value": [1, 0]})
+        cd = CD(pc)
+
+        cd.draw_circuit()
+        actual = cd.line_id_to_text
+        expect = \
+            {0:
+             "0 \033[0m |1>\033[0m ─\033[0m─\033[0m■\033[0m─\033[0m─\033[0m",
+             1: "         │ \033[0m ",
+             2:
+             "1 \033[0m |0>\033[0m ─\033[0m─\033[0m┼\033[0m─\033[0m─\033[0m",
+             3: "         │ \033[0m ",
+             4:
+             "2 \033[0m |0>\033[0m ─\033[0m─\033[0mo\033[0m─\033[0m─\033[0m",
+             5: "         │ \033[0m ",
+             6: "3 \033[0m |0>\033[0m ─\033[0m[X]\033[0m─\033[0m",
+             7: "            ",
+             8: "4 \033[0m |0>\033[0m ─\033[0m───\033[0m─\033[0m"}
+        self.assertEqual(actual, expect)
+
+    def test_color(self,):
+        pc = PauliCircuit(5)
+        pc.set_qubit_value(qubit_idx=[0], qubit_val=[1])
+        pc.add_gate({"name": "x", "control_qubit": [0, 2], "target_qubit": [3],
+                     "control_value": [1, 0]})
+        cd = CD(pc)
+        cd._color_code_line_1 = "\033[32m"
+
+        cd.draw_circuit()
+        actual = cd.line_id_to_text
+        expect = \
+            {0: "0 \033[0m \033[32m|1>\033[0m \033[32m─\033[0m\033[32m─"
+                + "\033[0m\033[32m■\033[0m\033[32m─\033[0m\033[32m─\033[0m",
+             1: "         │ \033[0m ",
+             2:
+             "1 \033[0m |0>\033[0m ─\033[0m─\033[0m┼\033[0m─\033[0m─\033[0m",
+             3: "         │ \033[0m ",
+             4:
+             "2 \033[0m |0>\033[0m ─\033[0m─\033[0mo\033[0m─\033[0m─\033[0m",
+             5: "         │ \033[0m ",
+             6: "3 \033[0m |0>\033[0m ─\033[0m[X]\033[0m\033[32m─\033[0m",
+             7: "            ",
+             8: "4 \033[0m |0>\033[0m ─\033[0m───\033[0m─\033[0m"}
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_ctrl.py
+++ b/test/simulator/circuit_drawer/test_draw_ctrl.py
@@ -1,0 +1,98 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawCtrl(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_ctrl
+    ....
+    ----------------------------------------------------------------------
+    Ran 4 tests in 0.002s
+
+    OK
+    $
+    """
+
+    def test_single(self,):
+        pc = PauliCircuit(2)
+        pc.add_gate({"name": "x", "control_qubit": [0], "target_qubit": [1],
+                     "control_value": [1]})
+        cd = CD(pc)
+
+        cd.draw_ctrl(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "─\033[0m■\033[0m─\033[0m",
+                  1: "",
+                  2: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [0]
+        self.assertEqual(actual, expect)
+
+    def test_multi(self,):
+        pc = PauliCircuit(3)
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                     "control_value": [1, 0]})
+        cd = CD(pc)
+
+        cd.draw_ctrl(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "─\033[0m■\033[0m─\033[0m",
+                  1: "",
+                  2: "─\033[0mo\033[0m─\033[0m",
+                  3: "",
+                  4: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [0, 2]
+        self.assertEqual(actual, expect)
+
+    def test_color_line(self,):
+        pc = PauliCircuit(3)
+        pc.set_qubit_value(qubit_idx=[0], qubit_val=[1])
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                     "control_value": [1, 0]})
+        cd = CD(pc)
+        cd._color_code_line_1 = "\033[32m"
+
+        cd.draw_ctrl(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "\033[32m─\033[0m\033[32m■\033[0m\033[32m─\033[0m",
+                  1: "",
+                  2: "─\033[0mo\033[0m─\033[0m",
+                  3: "",
+                  4: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [0, 2]
+        self.assertEqual(actual, expect)
+
+    def test_color_ctrl(self,):
+        pc = PauliCircuit(3)
+        pc.set_qubit_value(qubit_idx=[0], qubit_val=[1])
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                     "control_value": [1, 0]})
+        cd = CD(pc)
+        cd._color_code_line_1 = "\033[32m"
+        cd._color_code_ctrl = "\033[31m"
+
+        cd.draw_ctrl(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "\033[32m─\033[0m\033[31m■\033[0m\033[32m─\033[0m",
+                  1: "",
+                  2: "─\033[0m\033[31mo\033[0m─\033[0m",
+                  3: "",
+                  4: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [0, 2]
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_init_vector.py
+++ b/test/simulator/circuit_drawer/test_draw_init_vector.py
@@ -1,0 +1,35 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawInitVector(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_init_vector
+    .
+    ----------------------------------------------------------------------
+    Ran 1 test in 0.000s
+
+    OK
+    $
+    """
+
+    def test_default(self,):
+        pc = PauliCircuit(4)
+        pc.set_qubit_value(qubit_idx=[0, 1, 2, 3], qubit_val=[0, 1, 0, 1])
+        cd = CD(pc)
+
+        cd.draw_init_vector()
+        actual = cd.line_id_to_text
+        expect = {0: "|0>\033[0m",
+                  1: "   ",
+                  2: "|1>\033[0m",
+                  3: "   ",
+                  4: "|0>\033[0m",
+                  5: "   ",
+                  6: "|1>\033[0m"}
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_line.py
+++ b/test/simulator/circuit_drawer/test_draw_line.py
@@ -1,0 +1,48 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawLine(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_line
+    ..
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.001s
+
+    OK
+    $
+    """
+
+    def test_regular(self,):
+        pc = PauliCircuit(3)
+        cd = CD(pc)
+
+        cd.draw_line()
+        actual = cd.line_id_to_text
+        expect = {0: "─\033[0m",
+                  1: " ",
+                  2: "─\033[0m",
+                  3: " ",
+                  4: "─\033[0m"}
+        self.assertEqual(actual, expect)
+
+    def test_with_color(self,):
+        pc = PauliCircuit(3)
+        pc.set_qubit_value(qubit_idx=[0, 1, 2], qubit_val=[1, 0, 1])
+        cd = CD(pc)
+        cd._color_code_line_0 = ""
+        cd._color_code_line_1 = "\033[32m"
+
+        cd.draw_line()
+        actual = cd.line_id_to_text
+        expect = {0: "\033[32m─\033[0m",
+                  1: " ",
+                  2: "─\033[0m",
+                  3: " ",
+                  4: "\033[32m─\033[0m"}
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_one_gate.py
+++ b/test/simulator/circuit_drawer/test_draw_one_gate.py
@@ -1,0 +1,38 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawOneGate(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_one_gate
+    .
+    ----------------------------------------------------------------------
+    Ran 1 test in 0.001s
+
+    OK
+    $
+    """
+
+    def test_regular(self,):
+        pc = PauliCircuit(5)
+        pc.add_gate({"name": "x", "control_qubit": [0, 2], "target_qubit": [3],
+                     "control_value": [1, 0]})
+        cd = CD(pc)
+
+        cd.draw_one_gate(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "─\033[0m■\033[0m─\033[0m",
+                  1: " │ \033[0m",
+                  2: "─\033[0m┼\033[0m─\033[0m",
+                  3: " │ \033[0m",
+                  4: "─\033[0mo\033[0m─\033[0m",
+                  5: " │ \033[0m",
+                  6: "[X]\033[0m",
+                  7: "   ",
+                  8: "───\033[0m"}
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_qubit_identifier.py
+++ b/test/simulator/circuit_drawer/test_draw_qubit_identifier.py
@@ -1,0 +1,92 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawQubitIdentifier(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m \
+        unittest test.simulator.circuit_drawer.test_draw_qubit_identifier
+    ....
+    ----------------------------------------------------------------------
+    Ran 4 tests in 0.002s
+
+    OK
+    $
+    """
+
+    def test_default(self,):
+        pc = PauliCircuit(3)
+        cd = CD(pc)
+
+        cd.draw_qubit_indentifier()
+        actual = cd.line_id_to_text
+        expect = {0: "0 \033[0m",
+                  1: "  ",
+                  2: "1 \033[0m",
+                  3: "  ",
+                  4: "2 \033[0m"}
+        self.assertEqual(actual, expect)
+
+    def test_reg_name(self,):
+        pc = PauliCircuit(3)
+        cd = CD(pc)
+        cd._qubit_id_to_reg_name = {
+            0: "reg_1",
+            1: "",
+            2: " reg_2"
+        }
+
+        cd.draw_qubit_indentifier()
+        actual = cd.line_id_to_text
+        expect = {0: "0 reg_1\033[0m ",
+                  1: "        ",
+                  2: "1 \033[0m      ",
+                  3: "        ",
+                  4: "2  reg_2\033[0m"}
+        self.assertEqual(actual, expect)
+
+    def test_color_code(self,):
+        pc = PauliCircuit(3)
+        cd = CD(pc)
+        cd._qubit_id_to_color_code = {
+            0: "",
+            1: "\033[34m",
+            2: "\033[35m"
+        }
+
+        cd.draw_qubit_indentifier()
+        actual = cd.line_id_to_text
+        expect = {0: "0 \033[0m",
+                  1: "  ",
+                  2: "\033[34m1 \033[0m",
+                  3: "  ",
+                  4: "\033[35m2 \033[0m"}
+        self.assertEqual(actual, expect)
+
+    def test_reg_name_color_code(self,):
+        pc = PauliCircuit(3)
+        cd = CD(pc)
+        cd._qubit_id_to_reg_name = {
+            0: "reg_1",
+            1: "",
+            2: " reg_2"
+        }
+        cd._qubit_id_to_color_code = {
+            0: "",
+            1: "\033[34m",
+            2: "\033[35m"
+        }
+
+        cd.draw_qubit_indentifier()
+        actual = cd.line_id_to_text
+        expect = {0: "0 reg_1\033[0m ",
+                  1: "        ",
+                  2: "\033[34m1 \033[0m      ",
+                  3: "        ",
+                  4: "\033[35m2  reg_2\033[0m"}
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_rest.py
+++ b/test/simulator/circuit_drawer/test_draw_rest.py
@@ -1,0 +1,58 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawRest(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_rest
+    ..
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.001s
+
+    OK
+    $
+    """
+
+    def test_regular(self,):
+        pc = PauliCircuit(5)
+        cd = CD(pc)
+        cd._occupied_line_id = [0, 1, 6]
+
+        cd.draw_rest(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "",
+                  1: "",
+                  2: "───\033[0m",
+                  3: "   ",
+                  4: "───\033[0m",
+                  5: "   ",
+                  6: "",
+                  7: "   ",
+                  8: "───\033[0m"}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [0, 1, 6, 2, 3, 4, 5, 7, 8]
+        self.assertEqual(actual, expect)
+
+    def test_color(self,):
+        pc = PauliCircuit(2)
+        cd = CD(pc)
+        cd._color_code_line_0 = "\033[34m"
+        cd._occupied_line_id = [2]
+
+        cd.draw_rest(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "\033[34m───\033[0m",
+                  1: "   ",
+                  2: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [2, 0, 1]
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_space.py
+++ b/test/simulator/circuit_drawer/test_draw_space.py
@@ -1,0 +1,32 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawSpace(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_space
+    .
+    ----------------------------------------------------------------------
+    Ran 1 test in 0.000s
+
+    OK
+    $
+    """
+
+    def test_default(self,):
+        pc = PauliCircuit(3)
+        cd = CD(pc)
+
+        cd.draw_space()
+        actual = cd.line_id_to_text
+        expect = {0: " ",
+                  1: " ",
+                  2: " ",
+                  3: " ",
+                  4: " "}
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_tgt.py
+++ b/test/simulator/circuit_drawer/test_draw_tgt.py
@@ -1,0 +1,94 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawTgt(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_tgt
+    ....
+    ----------------------------------------------------------------------
+    Ran 4 tests in 0.003s
+
+    OK
+    $
+    """
+
+    def test_regular(self,):
+        pc = PauliCircuit(2)
+        pc.add_gate({"name": "x", "control_qubit": [], "target_qubit": [1],
+                     "control_value": []})
+        cd = CD(pc)
+
+        cd.draw_tgt(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "",
+                  1: "",
+                  2: "[X]\033[0m"}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [2]
+        self.assertEqual(actual, expect)
+
+    def test_multi(self,):
+        pc = PauliCircuit(2)
+        pc.add_gate({"name": "x", "control_qubit": [], "target_qubit": [0, 1],
+                     "control_value": []})
+        cd = CD(pc)
+
+        cd.draw_tgt(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "[X]\033[0m",
+                  1: "",
+                  2: "[X]\033[0m"}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [0, 2]
+        self.assertEqual(actual, expect)
+
+    def test_with_ctrl(self,):
+        pc = PauliCircuit(3)
+        pc.add_gate({"name": "x", "control_qubit": [], "target_qubit": [1],
+                     "control_value": []})
+        pc.add_gate({"name": "y", "control_qubit": [0, 1], "target_qubit": [2],
+                     "control_value": [1, 1]})
+        cd = CD(pc)
+
+        cd.draw_tgt(gate_id=1)
+        actual = cd.line_id_to_text
+        expect = {0: "",
+                  1: "",
+                  2: "",
+                  3: "",
+                  4: "[Y]\033[0m"}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [4]
+        self.assertEqual(actual, expect)
+
+    def test_with_color(self,):
+        pc = PauliCircuit(3)
+        pc.add_gate({"name": "z", "control_qubit": [0], "target_qubit": [1, 2],
+                     "control_value": [1]})
+        cd = CD(pc)
+        cd._color_code_tgt = "\033[31m"
+
+        cd.draw_tgt(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "",
+                  1: "",
+                  2: "\033[31m[Z]\033[0m",
+                  3: "",
+                  4: "\033[31m[Z]\033[0m"}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [2, 4]
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_draw_wire.py
+++ b/test/simulator/circuit_drawer/test_draw_wire.py
@@ -1,0 +1,101 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestDrawWire(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_draw_wire
+    ....
+    ----------------------------------------------------------------------
+    Ran 4 tests in 0.002s
+
+    OK
+    $
+    """
+
+    def test_one_wire(self,):
+        pc = PauliCircuit(3)
+        pc.add_gate({"name": "x", "control_qubit": [0], "target_qubit": [1],
+                     "control_value": [1]})
+        cd = CD(pc)
+
+        cd.draw_wire(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "",
+                  1: " │ \033[0m",
+                  2: "",
+                  3: "",
+                  4: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [1]
+        self.assertEqual(actual, expect)
+
+    def test_multi_wire(self,):
+        pc = PauliCircuit(3)
+        pc.add_gate({"name": "x", "control_qubit": [0], "target_qubit": [2],
+                     "control_value": [1]})
+        cd = CD(pc)
+
+        cd.draw_wire(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "",
+                  1: " │ \033[0m",
+                  2: "─\033[0m┼\033[0m─\033[0m",
+                  3: " │ \033[0m",
+                  4: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [1, 2, 3]
+        self.assertEqual(actual, expect)
+
+    def test_color_line(self,):
+        pc = PauliCircuit(3)
+        pc.set_qubit_value(qubit_idx=[1], qubit_val=[1])
+        pc.add_gate({"name": "x", "control_qubit": [0], "target_qubit": [2],
+                     "control_value": [1]})
+        cd = CD(pc)
+        cd._color_code_line_1 = "\033[32m"
+
+        cd.draw_wire(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "",
+                  1: " │ \033[0m",
+                  2: "\033[32m─\033[0m┼\033[0m\033[32m─\033[0m",
+                  3: " │ \033[0m",
+                  4: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [1, 2, 3]
+        self.assertEqual(actual, expect)
+
+    def test_color_wire(self,):
+        pc = PauliCircuit(3)
+        pc.set_qubit_value(qubit_idx=[1], qubit_val=[1])
+        pc.add_gate({"name": "x", "control_qubit": [0], "target_qubit": [2],
+                     "control_value": [1]})
+        cd = CD(pc)
+        cd._color_code_line_1 = "\033[32m"
+        cd._color_code_cross = "\033[31m"
+        cd._color_code_wire = "\033[31m"
+
+        cd.draw_wire(gate_id=0)
+        actual = cd.line_id_to_text
+        expect = {0: "",
+                  1: "\033[31m │ \033[0m",
+                  2: "\033[32m─\033[0m\033[31m┼\033[0m\033[32m─\033[0m",
+                  3: "\033[31m │ \033[0m",
+                  4: ""}
+        self.assertEqual(actual, expect)
+
+        actual = cd._occupied_line_id
+        expect = [1, 2, 3]
+        self.assertEqual(actual, expect)

--- a/test/simulator/circuit_drawer/test_get_methods.py
+++ b/test/simulator/circuit_drawer/test_get_methods.py
@@ -1,0 +1,81 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer as CD
+
+
+class TestGetMethods(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.circuit_drawer.test_get_methods
+    .........
+    ----------------------------------------------------------------------
+    Ran 9 tests in 0.003s
+
+    OK
+    $
+    """
+
+    def test_get_color_code_line(self,):
+        pc = PauliCircuit(10)
+        cd = CD(pc)
+        cd._color_code_line_0 = "\033[32m"
+        cd._color_code_line_1 = "\033[35m"
+
+        self.assertEqual(cd.get_color_code_line(qubit_val=0), "\033[32m")
+        self.assertEqual(cd.get_color_code_line(qubit_val=1), "\033[35m")
+
+    def test_get_line(self,):
+        actual = CD.get_line(1, length=4, color_code="\033[32m")
+        expect = "\033[32m────\033[0m"
+        self.assertEqual(actual, expect)
+
+    def test_get_cross_line(self,):
+        actual = CD.get_cross_line(
+            1, color_code_cross="\033[31m", color_code_line="\033[32m")
+        expect = "\033[32m─\033[0m\033[31m┼\033[0m\033[32m─\033[0m"
+        self.assertEqual(actual, expect)
+
+    def test_get_wire(self,):
+        actual = CD.get_wire(color_code="\033[32m")
+        expect = "\033[32m │ \033[0m"
+        self.assertEqual(actual, expect)
+
+    def test_get_space(self,):
+        actual = CD.get_space(length=4)
+        expect = "    "
+        self.assertEqual(actual, expect)
+
+    def test_get_tgt(self,):
+        name_lst = ["x", "y", "z", "swap"]
+        obj_lst = ["[X]", "[Y]", "[Z]", "SWP"]
+        for name, obj in zip(name_lst, obj_lst):
+            actual = CD.get_tgt(name, 1, color_code="\033[35m")
+            expect = "\033[35m" + obj + "\033[0m"
+            self.assertEqual(actual, expect)
+
+    def test_get_ctrl(self,):
+        ctrl_val_lst = [1, 0]
+        obj_lst = ["■", "o"]
+        for ctrl_val, obj in zip(ctrl_val_lst, obj_lst):
+            actual = CD.get_ctrl(ctrl_val, 1, color_code_ctrl="\033[31m",
+                                 color_code_line="\033[32m")
+            expect = "\033[32m─\033[0m\033[31m" + \
+                obj + "\033[0m\033[32m─\033[0m"
+            self.assertEqual(actual, expect)
+
+    def test_get_init_state(self,):
+        qubit_val_lst = [1, 0]
+        obj_lst = ["|1>", "|0>"]
+        color_code_lst = ["\033[32m", ""]
+        for qubit_val, obj, cc in zip(qubit_val_lst, obj_lst, color_code_lst):
+            actual = CD.get_init_state(qubit_val, color_code=cc)
+            expect = cc + obj + "\033[0m"
+            self.assertEqual(actual, expect)
+
+    def test_get_inter_line_id(self,):
+        actual = CD.get_inter_line_id(2, 6)
+        expect = [3, 4, 5]
+        self.assertEqual(actual, expect)

--- a/test/simulator/pauli_circuit/test_draw.py
+++ b/test/simulator/pauli_circuit/test_draw.py
@@ -1,0 +1,41 @@
+import unittest
+
+from quantestpy import PauliCircuit
+from quantestpy.simulator.circuit_drawer import CircuitDrawer
+
+
+class TestDraw(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.pauli_circuit.test_draw
+    .
+    ----------------------------------------------------------------------
+    Ran 1 test in 0.001s
+
+    OK
+    $
+    """
+
+    def test_only_successful_call(self,):
+        circ = PauliCircuit(15)
+        circ.add_gate(
+            {"name": "x",
+             "target_qubit": [3],
+             "control_qubit": [0, 1],
+             "control_value": [1, 1]}
+        )
+        circ.add_gate(
+            {"name": "y",
+             "target_qubit": [10, 11, 12],
+             "control_qubit": [5],
+             "control_value": [0]}
+        )
+        circ.add_gate(
+            {"name": "swap",
+             "target_qubit": [1, 7],
+             "control_qubit": [0],
+             "control_value": [0]}
+        )
+        self.assertIsInstance(circ.draw(), CircuitDrawer)


### PR DESCRIPTION
In this PR I add a new method `draw()` in PauliCircuit class to draw the circuit. 
An example is in the doc 👇  
https://github.com/QuantestPy/quantestpy/blob/issue159/doc/pauli_circuit_draw.md