### PR TITLE
Rename TestCircuit->StateVectorCircuit, add QuantestPyCircuit as the base class of StateVectorCircuit and PauliCircuit.

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,6 +1,6 @@
 name: github-actions
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/quantestpy/__init__.py
+++ b/quantestpy/__init__.py
@@ -1,3 +1,4 @@
+from .simulator.quantestpy_circuit import QuantestPyCircuit
+from .simulator.state_vector_circuit import StateVectorCircuit
 from .simulator.pauli_circuit import PauliCircuit
-from .test_circuit import TestCircuit
 from .assertion.get_ctrl_val import assert_get_ctrl_val

--- a/quantestpy/assertion/get_ctrl_val.py
+++ b/quantestpy/assertion/get_ctrl_val.py
@@ -1,10 +1,11 @@
-import copy
 import unittest
 
 import numpy as np
 
-from quantestpy import PauliCircuit
+from quantestpy.converter.all import cvt_all_circuit_to_quantestpy_circuit
 from quantestpy.exceptions import QuantestPyAssertionError, QuantestPyError
+from quantestpy.simulator.pauli_circuit import (
+    PauliCircuit, cvt_quantestpy_circuit_to_pauli_circuit)
 
 ut_test_case = unittest.TestCase()
 
@@ -37,15 +38,16 @@ def _get_qubit_idx_to_qubit_val_for_given_val_in_ctrl_reg(
 
 
 def assert_get_ctrl_val(
-        circuit: PauliCircuit,
+        circuit,
         ctrl_reg: list,
         ancilla_reg: list = [],
         check_ancilla_is_uncomputed: bool = False,
         print_out_result: bool = True) -> dict:
 
+    quantestpy_circuit = cvt_all_circuit_to_quantestpy_circuit(circuit)
+    pc = cvt_quantestpy_circuit_to_pauli_circuit(quantestpy_circuit)
+
     # check inputs
-    PauliCircuit._assert_is_pauli_circuit(circuit)
-    pc = copy.deepcopy(circuit)
     pc._assert_is_correct_reg(ctrl_reg)
     pc._assert_is_correct_reg(ancilla_reg)
     if not isinstance(check_ancilla_is_uncomputed, bool):

--- a/quantestpy/assertion/get_ctrl_val.py
+++ b/quantestpy/assertion/get_ctrl_val.py
@@ -2,7 +2,8 @@ import unittest
 
 import numpy as np
 
-from quantestpy.converter.all import cvt_all_circuit_to_quantestpy_circuit
+from quantestpy.converter.converter_to_quantestpy_circuit import \
+    cvt_input_circuit_to_quantestpy_circuit
 from quantestpy.exceptions import QuantestPyAssertionError, QuantestPyError
 from quantestpy.simulator.pauli_circuit import (
     PauliCircuit, cvt_quantestpy_circuit_to_pauli_circuit)
@@ -44,7 +45,7 @@ def assert_get_ctrl_val(
         check_ancilla_is_uncomputed: bool = False,
         print_out_result: bool = True) -> dict:
 
-    quantestpy_circuit = cvt_all_circuit_to_quantestpy_circuit(circuit)
+    quantestpy_circuit = cvt_input_circuit_to_quantestpy_circuit(circuit)
     pc = cvt_quantestpy_circuit_to_pauli_circuit(quantestpy_circuit)
 
     # check inputs

--- a/quantestpy/circuit.py
+++ b/quantestpy/circuit.py
@@ -7,7 +7,8 @@ from typing import Union
 import numpy as np
 
 from quantestpy import QuantestPyCircuit, operator
-from quantestpy.converter.all import cvt_all_circuit_to_quantestpy_circuit
+from quantestpy.converter.converter_to_quantestpy_circuit import \
+    cvt_input_circuit_to_quantestpy_circuit
 from quantestpy.exceptions import QuantestPyAssertionError, QuantestPyError
 from quantestpy.simulator.state_vector_circuit import \
     cvt_quantestpy_circuit_to_state_vector_circuit
@@ -25,7 +26,7 @@ def assert_equal_to_operator(
         matrix_norm_type: Union[str, None] = None,
         msg=None) -> None:
 
-    quantestpy_circuit = cvt_all_circuit_to_quantestpy_circuit(circuit)
+    quantestpy_circuit = cvt_input_circuit_to_quantestpy_circuit(circuit)
     state_vector_circuit = cvt_quantestpy_circuit_to_state_vector_circuit(
         quantestpy_circuit
     )
@@ -56,7 +57,7 @@ def assert_is_zero(circuit: Union[QuantestPyCircuit, str],
             "qubits must be a list of integer(s) as qubit's ID(s)."
         )
 
-    quantestpy_circuit = cvt_all_circuit_to_quantestpy_circuit(circuit)
+    quantestpy_circuit = cvt_input_circuit_to_quantestpy_circuit(circuit)
     state_vector_circuit = cvt_quantestpy_circuit_to_state_vector_circuit(
         quantestpy_circuit
     )
@@ -109,7 +110,7 @@ def assert_ancilla_is_zero(circuit: Union[QuantestPyCircuit, str],
             "ancilla_qubits must be a list of integer(s) as qubit's ID(s)."
         )
 
-    quantestpy_circuit = cvt_all_circuit_to_quantestpy_circuit(circuit)
+    quantestpy_circuit = cvt_input_circuit_to_quantestpy_circuit(circuit)
 
     num_qubit = quantestpy_circuit.num_qubit
 
@@ -198,8 +199,8 @@ def assert_equal(
             "Type of rtol must be float."
         )
 
-    quantestpy_circuit_a = cvt_all_circuit_to_quantestpy_circuit(circuit_a)
-    quantestpy_circuit_b = cvt_all_circuit_to_quantestpy_circuit(circuit_b)
+    quantestpy_circuit_a = cvt_input_circuit_to_quantestpy_circuit(circuit_a)
+    quantestpy_circuit_b = cvt_input_circuit_to_quantestpy_circuit(circuit_b)
 
     state_vector_circuit_a = cvt_quantestpy_circuit_to_state_vector_circuit(
         quantestpy_circuit_a

--- a/quantestpy/circuit.py
+++ b/quantestpy/circuit.py
@@ -34,10 +34,11 @@ def assert_equal_to_operator(
     state_vector_circuit._from_right_to_left_for_qubit_ids = \
         from_right_to_left_for_qubit_ids
 
-    operator_from_test_circuit = state_vector_circuit._get_whole_gates()
+    operator_from_state_vector_circuit = \
+        state_vector_circuit._get_whole_gates()
 
     operator.assert_equal(
-        operator_from_test_circuit,
+        operator_from_state_vector_circuit,
         operator_,
         rtol,
         atol,
@@ -134,7 +135,7 @@ def assert_ancilla_is_zero(circuit: Union[QuantestPyCircuit, str],
     error_msgs_from_assert_is_zero = []
     for comb_of_sys_qubits in all_combinations_of_system_qubits:
 
-        # add x gate(s) in test_circuit
+        # add x gate(s) in quantestpy_circuit
         for system_qubit in comb_of_sys_qubits:
             _add_x_gate_in_front(quantestpy_circuit._gates, system_qubit)
 
@@ -148,7 +149,8 @@ def assert_ancilla_is_zero(circuit: Union[QuantestPyCircuit, str],
             t = traceback.format_exception_only(type(e), e)[0]
             error_msgs_from_assert_is_zero.append(t)
 
-        # remove x gate(s) from test_circuit, i.e. reset test_circuit.
+        # remove x gate(s) from quantestpy_circuit,
+        # i.e. reset quantestpy_circuit.
         for _ in comb_of_sys_qubits:
             del quantestpy_circuit._gates[0]
 

--- a/quantestpy/converter/all.py
+++ b/quantestpy/converter/all.py
@@ -1,0 +1,28 @@
+from quantestpy import QuantestPyCircuit
+from quantestpy.converter.qasm_and_qiskit import (
+    _cvt_openqasm_to_quantestpy_circuit, _cvt_qiskit_to_quantestpy_circuit,
+    _is_instance_of_qiskit_quantumcircuit)
+from quantestpy.exceptions import QuantestPyError
+
+
+def cvt_all_circuit_to_quantestpy_circuit(circuit) -> QuantestPyCircuit:
+
+    # test_circuit
+    if isinstance(circuit, QuantestPyCircuit):
+        quantestpy_circuit = circuit
+
+    # qasm
+    elif isinstance(circuit, str):
+        quantestpy_circuit = _cvt_openqasm_to_quantestpy_circuit(circuit)
+
+    # qiskit.QuantumCircuit()
+    elif _is_instance_of_qiskit_quantumcircuit(circuit):
+        quantestpy_circuit = _cvt_qiskit_to_quantestpy_circuit(circuit)
+
+    else:
+        raise QuantestPyError(
+            "Input circuit must be one of the following: "
+            "qasm, qiskit.QuantumCircuit and QuantestPyCircuit."
+        )
+
+    return quantestpy_circuit

--- a/quantestpy/converter/converter_to_quantestpy_circuit.py
+++ b/quantestpy/converter/converter_to_quantestpy_circuit.py
@@ -7,7 +7,7 @@ from quantestpy.exceptions import QuantestPyError
 
 def cvt_input_circuit_to_quantestpy_circuit(circuit) -> QuantestPyCircuit:
 
-    # test_circuit
+    # QuantestPyCircuit
     if isinstance(circuit, QuantestPyCircuit):
         quantestpy_circuit = circuit
 

--- a/quantestpy/converter/converter_to_quantestpy_circuit.py
+++ b/quantestpy/converter/converter_to_quantestpy_circuit.py
@@ -1,11 +1,11 @@
 from quantestpy import QuantestPyCircuit
-from quantestpy.converter.qasm_and_qiskit import (
-    _cvt_openqasm_to_quantestpy_circuit, _cvt_qiskit_to_quantestpy_circuit,
-    _is_instance_of_qiskit_quantumcircuit)
+from quantestpy.converter.sdk.qasm import _cvt_openqasm_to_quantestpy_circuit
+from quantestpy.converter.sdk.qiskit import (
+    _cvt_qiskit_to_quantestpy_circuit, _is_instance_of_qiskit_quantumcircuit)
 from quantestpy.exceptions import QuantestPyError
 
 
-def cvt_all_circuit_to_quantestpy_circuit(circuit) -> QuantestPyCircuit:
+def cvt_input_circuit_to_quantestpy_circuit(circuit) -> QuantestPyCircuit:
 
     # test_circuit
     if isinstance(circuit, QuantestPyCircuit):

--- a/quantestpy/converter/qasm_and_qiskit.py
+++ b/quantestpy/converter/qasm_and_qiskit.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from quantestpy import TestCircuit
+from quantestpy import QuantestPyCircuit
 from quantestpy.exceptions import QuantestPyError
 
 try:
@@ -19,7 +19,7 @@ def _raise_error_if_not_qiskit_installed():
         )
 
 
-def _cvt_qiskit_to_test_circuit(qiskit_circuit) -> TestCircuit:
+def _cvt_qiskit_to_quantestpy_circuit(qiskit_circuit) -> QuantestPyCircuit:
 
     _raise_error_if_not_qiskit_installed()
 
@@ -30,7 +30,7 @@ def _cvt_qiskit_to_test_circuit(qiskit_circuit) -> TestCircuit:
     gates = experiments["instructions"]
     num_qubits = experiments["config"]["n_qubits"]
     global_phase = experiments["header"]["global_phase"]
-    circuit = TestCircuit(num_qubits)
+    circuit = QuantestPyCircuit(num_qubits)
 
     for gate in gates:
 
@@ -92,12 +92,12 @@ def _cvt_qiskit_to_test_circuit(qiskit_circuit) -> TestCircuit:
     return circuit
 
 
-def _cvt_openqasm_to_test_circuit(qasm: str) -> TestCircuit:
+def _cvt_openqasm_to_quantestpy_circuit(qasm: str) -> QuantestPyCircuit:
 
     _raise_error_if_not_qiskit_installed()
 
     qiskit_circuit = QuantumCircuit.from_qasm_str(qasm)
-    return _cvt_qiskit_to_test_circuit(qiskit_circuit)
+    return _cvt_qiskit_to_quantestpy_circuit(qiskit_circuit)
 
 
 def _is_instance_of_qiskit_quantumcircuit(circuit) -> bool:

--- a/quantestpy/converter/sdk/qasm.py
+++ b/quantestpy/converter/sdk/qasm.py
@@ -1,0 +1,17 @@
+from quantestpy import QuantestPyCircuit
+from quantestpy.converter.sdk.qiskit import (
+    _cvt_qiskit_to_quantestpy_circuit, _raise_error_if_not_qiskit_installed)
+
+try:
+    from qiskit import QuantumCircuit
+
+except ModuleNotFoundError:
+    pass
+
+
+def _cvt_openqasm_to_quantestpy_circuit(qasm: str) -> QuantestPyCircuit:
+
+    _raise_error_if_not_qiskit_installed()
+
+    qiskit_circuit = QuantumCircuit.from_qasm_str(qasm)
+    return _cvt_qiskit_to_quantestpy_circuit(qiskit_circuit)

--- a/quantestpy/converter/sdk/qiskit.py
+++ b/quantestpy/converter/sdk/qiskit.py
@@ -92,14 +92,6 @@ def _cvt_qiskit_to_quantestpy_circuit(qiskit_circuit) -> QuantestPyCircuit:
     return circuit
 
 
-def _cvt_openqasm_to_quantestpy_circuit(qasm: str) -> QuantestPyCircuit:
-
-    _raise_error_if_not_qiskit_installed()
-
-    qiskit_circuit = QuantumCircuit.from_qasm_str(qasm)
-    return _cvt_qiskit_to_quantestpy_circuit(qiskit_circuit)
-
-
 def _is_instance_of_qiskit_quantumcircuit(circuit) -> bool:
 
     _raise_error_if_not_qiskit_installed()

--- a/quantestpy/simulator/exceptions.py
+++ b/quantestpy/simulator/exceptions.py
@@ -1,0 +1,10 @@
+class QuantestPyCircuitError(Exception):
+    pass
+
+
+class StateVectorCircuitError(Exception):
+    pass
+
+
+class PauliCircuitError(Exception):
+    pass

--- a/quantestpy/simulator/quantestpy_circuit.py
+++ b/quantestpy/simulator/quantestpy_circuit.py
@@ -1,0 +1,164 @@
+from quantestpy.simulator.exceptions import QuantestPyCircuitError
+
+
+class QuantestPyCircuit:
+    """
+    This class will be used as a base circuit class for other
+    circuit classes.
+    """
+
+    def __init__(self, num_qubit: int):
+        if not isinstance(num_qubit, int) or num_qubit < 1:
+            raise QuantestPyCircuitError(
+                "num_qubit must be an integer greater than 0."
+            )
+        self._gates = []
+        self._qubit_indices = [i for i in range(num_qubit)]
+        self._num_qubit = num_qubit
+
+    @property
+    def gates(self):
+        return self._gates
+
+    @property
+    def num_qubit(self):
+        return self._num_qubit
+
+    @property
+    def qubit_indices(self):
+        return self._qubit_indices
+
+    def _diagnostic_gate(self, gate: dict) -> None:
+        """
+        Example
+        gate = {"name": "x", "target_qubit": [1], "control_qubit": [],
+                "control_value": [], "parameter": []}
+        gate = {"name": "rx", "target_qubit": [1], "control_qubit": [0],
+                "control_value": [1], "parameter": [np.pi/8]}
+        """
+        if not isinstance(gate, dict):
+            raise QuantestPyCircuitError(
+                "gate's type must be dictionary which contains 'name', "
+                "'target_qubit' and optionally 'control_qubit' as keys."
+            )
+
+        if "name" not in gate.keys():
+            raise QuantestPyCircuitError(
+                "gate must contain 'name' as a key."
+            )
+
+        if "target_qubit" not in gate.keys():
+            raise QuantestPyCircuitError(
+                "gate must contain 'target_qubit' as a key."
+            )
+
+        if "control_qubit" not in gate.keys():
+            raise QuantestPyCircuitError(
+                "gate must contain 'control_qubit' as a key."
+            )
+
+        if "control_value" not in gate.keys():
+            raise QuantestPyCircuitError(
+                "gate must contain 'control_value' as a key."
+            )
+
+        if not isinstance(gate["target_qubit"], list):
+            raise QuantestPyCircuitError(
+                'gate["target_qubit"] must be a list'
+            )
+
+        if not isinstance(gate["control_qubit"], list):
+            raise QuantestPyCircuitError(
+                'gate["control_qubit"] must be a list'
+            )
+
+        if not isinstance(gate["control_value"], list):
+            raise QuantestPyCircuitError(
+                'gate["control_value"] must be a list'
+            )
+
+        if len(gate["control_qubit"]) != len(gate["control_value"]):
+            raise QuantestPyCircuitError(
+                "control_qubit and control_value must have the same lenght."
+            )
+
+        if len(gate["target_qubit"]) < 1:
+            raise QuantestPyCircuitError(
+                "'target_qubit' must not an empty list."
+            )
+
+        for qubit in gate["target_qubit"]:
+            if not isinstance(qubit, int):
+                raise QuantestPyCircuitError(
+                    "Index in target_qubit must be integer type."
+                )
+
+            if qubit not in self._qubit_indices:
+                raise QuantestPyCircuitError(
+                    f"Index {qubit} in target_qubit out of range for "
+                    f"test_circuit size {self._num_qubit}."
+                )
+
+        for qubit in gate["control_qubit"]:
+            if not isinstance(qubit, int):
+                raise QuantestPyCircuitError(
+                    "Index in control_qubit must be integer type."
+                )
+
+            if qubit not in self._qubit_indices:
+                raise QuantestPyCircuitError(
+                    f"Index {qubit} in control_qubit out of range for "
+                    f"test_circuit size {self._num_qubit}."
+                )
+
+        for value in gate["control_value"]:
+            if not isinstance(value, int):
+                raise QuantestPyCircuitError(
+                    "Value in control_value must be integer type."
+                )
+
+            if value not in [0, 1]:
+                raise QuantestPyCircuitError(
+                    f"Value {value} in control_value is not acceptable. "
+                    "It must be either 0 or 1."
+                )
+
+        if len(gate["target_qubit"]) != len(set(gate["target_qubit"])):
+            raise QuantestPyCircuitError(
+                "Duplicate in target_qubit is not supported."
+            )
+
+        if len(gate["control_qubit"]) != len(set(gate["control_qubit"])):
+            raise QuantestPyCircuitError(
+                "Duplicate in control_qubit is not supported."
+            )
+
+        if len(list(set(gate["target_qubit"]) & set(gate["control_qubit"]))) \
+                > 0:
+            raise QuantestPyCircuitError(
+                f'target_qubit {gate["target_qubit"]} and '
+                f'control_qubit {gate["control_qubit"]} have intersection.'
+            )
+
+        if gate["name"] in ["swap", "iswap"] and \
+                len(gate["target_qubit"]) != 2:
+            raise QuantestPyCircuitError(
+                f'{gate["name"]} gate must have a list '
+                "containing exactly 2 elements for 'target_qubit'."
+            )
+
+    def add_gate(self, gate: dict) -> None:
+        self._diagnostic_gate(gate)
+        self._gates.append(gate)
+
+
+if __name__ == "__main__":
+    """Example showing how to use QuantestPyCircuit class."""
+
+    circ = QuantestPyCircuit(3)
+    circ.add_gate({"name": "x", "target_qubit": [0], "control_qubit": [],
+                   "control_value": [], "parameter": []})
+    circ.add_gate({"name": "x", "target_qubit": [2], "control_qubit": [0],
+                   "control_value": [1], "parameter": []})
+    circ.add_gate({"name": "h", "target_qubit": [0], "control_qubit": [],
+                   "control_value": [], "parameter": []})

--- a/quantestpy/simulator/quantestpy_circuit.py
+++ b/quantestpy/simulator/quantestpy_circuit.py
@@ -64,22 +64,22 @@ class QuantestPyCircuit:
 
         if not isinstance(gate["target_qubit"], list):
             raise QuantestPyCircuitError(
-                'gate["target_qubit"] must be a list'
+                'gate["target_qubit"] must be a list.'
             )
 
         if not isinstance(gate["control_qubit"], list):
             raise QuantestPyCircuitError(
-                'gate["control_qubit"] must be a list'
+                'gate["control_qubit"] must be a list.'
             )
 
         if not isinstance(gate["control_value"], list):
             raise QuantestPyCircuitError(
-                'gate["control_value"] must be a list'
+                'gate["control_value"] must be a list.'
             )
 
         if len(gate["control_qubit"]) != len(gate["control_value"]):
             raise QuantestPyCircuitError(
-                "control_qubit and control_value must have the same lenght."
+                "control_qubit and control_value must have the same length."
             )
 
         if len(gate["target_qubit"]) < 1:

--- a/quantestpy/simulator/quantestpy_circuit.py
+++ b/quantestpy/simulator/quantestpy_circuit.py
@@ -96,7 +96,7 @@ class QuantestPyCircuit:
             if qubit not in self._qubit_indices:
                 raise QuantestPyCircuitError(
                     f"Index {qubit} in target_qubit out of range for "
-                    f"test_circuit size {self._num_qubit}."
+                    f"circuit size {self._num_qubit}."
                 )
 
         for qubit in gate["control_qubit"]:
@@ -108,7 +108,7 @@ class QuantestPyCircuit:
             if qubit not in self._qubit_indices:
                 raise QuantestPyCircuitError(
                     f"Index {qubit} in control_qubit out of range for "
-                    f"test_circuit size {self._num_qubit}."
+                    f"circuit size {self._num_qubit}."
                 )
 
         for value in gate["control_value"]:

--- a/quantestpy/simulator/state_vector_circuit.py
+++ b/quantestpy/simulator/state_vector_circuit.py
@@ -65,9 +65,8 @@ _IMPLEMENTED_GATES = _IMPLEMENTED_GATES_WITHOUT_PARAM \
 
 class StateVectorCircuit(QuantestPyCircuit):
     """
-    This circuit class will be always used as an input to assert methods
-    which deal with circuits. Mathematical operations such as applying gates
-    will be executed using the methods of this class.
+    This circuit class will be used inside the assert methods which deal with
+    state vectors.
     """
 
     def __init__(self, num_qubit: int):

--- a/test/assertion/get_ctrl_val/test_assert_get_ctrl_val.py
+++ b/test/assertion/get_ctrl_val/test_assert_get_ctrl_val.py
@@ -1,6 +1,6 @@
 import unittest
 
-from quantestpy import PauliCircuit, assert_get_ctrl_val
+from quantestpy import QuantestPyCircuit, assert_get_ctrl_val
 
 
 class TestAssertGetCtrlVal(unittest.TestCase):
@@ -21,7 +21,7 @@ class TestAssertGetCtrlVal(unittest.TestCase):
         """
         This is the circuit in Figure 7 in arxiv:1805.03662
         """
-        self.pc = PauliCircuit(1+4+11+4)
+        self.pc = QuantestPyCircuit(1+4+11+4)
         self.pc.add_gate({"name": "x", "target_qubit": [16],
                           "control_qubit": [0, 1], "control_value": [1, 0]})
         self.pc.add_gate({"name": "x", "target_qubit": [17],

--- a/test/converter/qasm/test_converter_without_qiskit.py
+++ b/test/converter/qasm/test_converter_without_qiskit.py
@@ -11,7 +11,7 @@ class TestConverterWithoutQiskit(unittest.TestCase):
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
     $ python -m \
-        unittest test.converter.qasm_and_qiskit.test_converter_without_qiskit
+        unittest test.converter.qasm.test_converter_without_qiskit
     ...
     ----------------------------------------------------------------------
     Ran 5 tests in 0.041s

--- a/test/converter/qasm_and_qiskit/test_converter_without_qiskit.py
+++ b/test/converter/qasm_and_qiskit/test_converter_without_qiskit.py
@@ -1,7 +1,8 @@
 import traceback
 import unittest
 
-from quantestpy.converter import _cvt_openqasm_to_test_circuit
+from quantestpy.converter.qasm_and_qiskit import \
+    _cvt_openqasm_to_quantestpy_circuit
 from quantestpy.exceptions import QuantestPyError
 
 
@@ -10,7 +11,8 @@ class TestConverter(unittest.TestCase):
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_converter_without_qiskit
+    $ python -m \
+        unittest test.converter.qasm_and_qiskit.test_converter_without_qiskit
     ...
     ----------------------------------------------------------------------
     Ran 5 tests in 0.041s
@@ -22,10 +24,10 @@ class TestConverter(unittest.TestCase):
         qasm = 'OPENQASM 2.0;\ninclude "qelib1.inc";\nqreg q[2];\nx q[0];\n'
 
         with self.assertRaises(QuantestPyError):
-            _ = _cvt_openqasm_to_test_circuit(qasm)
+            _ = _cvt_openqasm_to_quantestpy_circuit(qasm)
 
         try:
-            _ = _cvt_openqasm_to_test_circuit(qasm)
+            _ = _cvt_openqasm_to_quantestpy_circuit(qasm)
 
         except QuantestPyError as e:
             expected_error_msg = "quantestpy.exceptions.QuantestPyError: " \

--- a/test/converter/qasm_and_qiskit/test_converter_without_qiskit.py
+++ b/test/converter/qasm_and_qiskit/test_converter_without_qiskit.py
@@ -1,12 +1,11 @@
 import traceback
 import unittest
 
-from quantestpy.converter.qasm_and_qiskit import \
-    _cvt_openqasm_to_quantestpy_circuit
+from quantestpy.converter.sdk.qasm import _cvt_openqasm_to_quantestpy_circuit
 from quantestpy.exceptions import QuantestPyError
 
 
-class TestConverter(unittest.TestCase):
+class TestConverterWithoutQiskit(unittest.TestCase):
     """
     How to execute this test:
     $ pwd

--- a/test/simulator/pauli_circuit/test_add_gate.py
+++ b/test/simulator/pauli_circuit/test_add_gate.py
@@ -1,7 +1,7 @@
 import unittest
 
 from quantestpy import PauliCircuit
-from quantestpy.exceptions import QuantestPyTestCircuitError
+from quantestpy.simulator.exceptions import PauliCircuitError
 from quantestpy.simulator.pauli_circuit import _IMPLEMENTED_GATES
 
 
@@ -56,7 +56,7 @@ class TestAddGate(unittest.TestCase):
             'rz gate is not implemented.\n' \
             + f'Implemented gates: {_IMPLEMENTED_GATES}'
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             circ.add_gate(
                 {"name": "rz",
                  "target_qubit": [20],

--- a/test/simulator/pauli_circuit/test_assert_is_correct_qubit_val.py
+++ b/test/simulator/pauli_circuit/test_assert_is_correct_qubit_val.py
@@ -2,7 +2,7 @@ import random
 import unittest
 
 from quantestpy import PauliCircuit
-from quantestpy.exceptions import QuantestPyTestCircuitError
+from quantestpy.simulator.exceptions import PauliCircuitError
 
 
 class TestAssertIsCorrectQubitVal(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestAssertIsCorrectQubitVal(unittest.TestCase):
         qubit_value = 0
         expected_error_msg = "qubit_val must be a list."
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             circ._assert_is_correct_qubit_val(qubit_val=qubit_value)
 
         self.assertEqual(cm.exception.args[0], expected_error_msg)
@@ -42,7 +42,7 @@ class TestAssertIsCorrectQubitVal(unittest.TestCase):
         qubit_value = [0., 1]
         expected_error_msg = "Values in qubit_val must be integer type."
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             circ._assert_is_correct_qubit_val(qubit_val=qubit_value)
 
         self.assertEqual(cm.exception.args[0], expected_error_msg)
@@ -52,7 +52,7 @@ class TestAssertIsCorrectQubitVal(unittest.TestCase):
         qubit_value = [0, 1, 2]
         expected_error_msg = "Values in qubit_val must be either 0 or 1."
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             circ._assert_is_correct_qubit_val(qubit_val=qubit_value)
 
         self.assertEqual(cm.exception.args[0], expected_error_msg)

--- a/test/simulator/pauli_circuit/test_assert_is_correct_reg.py
+++ b/test/simulator/pauli_circuit/test_assert_is_correct_reg.py
@@ -2,7 +2,7 @@ import random
 import unittest
 
 from quantestpy import PauliCircuit
-from quantestpy.exceptions import QuantestPyTestCircuitError
+from quantestpy.simulator.exceptions import PauliCircuitError
 
 
 class TestAssertIsCorrectReg(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestAssertIsCorrectReg(unittest.TestCase):
         register = {0, 1, 2}
         expected_error_msg = "register must be a list."
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             circ._assert_is_correct_reg(register=register)
 
         self.assertEqual(cm.exception.args[0], expected_error_msg)
@@ -42,7 +42,7 @@ class TestAssertIsCorrectReg(unittest.TestCase):
         register = [10.]
         expected_error_msg = "Indices in register must be integer type."
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             circ._assert_is_correct_reg(register=register)
 
         self.assertEqual(cm.exception.args[0], expected_error_msg)
@@ -52,7 +52,7 @@ class TestAssertIsCorrectReg(unittest.TestCase):
         register = [99, 100]
         expected_error_msg = "Qubit index 100 in register is out of range."
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             circ._assert_is_correct_reg(register=register)
 
         self.assertEqual(cm.exception.args[0], expected_error_msg)

--- a/test/simulator/pauli_circuit/test_assert_is_correct_reg_and_qubit_val.py
+++ b/test/simulator/pauli_circuit/test_assert_is_correct_reg_and_qubit_val.py
@@ -2,7 +2,7 @@ import random
 import unittest
 
 from quantestpy import PauliCircuit
-from quantestpy.exceptions import QuantestPyTestCircuitError
+from quantestpy.simulator.exceptions import PauliCircuitError
 
 
 class TestAssertIsCorrectRegAndQubitVal(unittest.TestCase):
@@ -38,7 +38,7 @@ class TestAssertIsCorrectRegAndQubitVal(unittest.TestCase):
         expected_error_msg = "Length of register and that of " \
             + "qubit_val must be the same."
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             circ._assert_is_correct_reg_and_qubit_val(
                 register=register,
                 qubit_val=qubit_value

--- a/test/simulator/pauli_circuit/test_assert_is_pauli_circuit.py
+++ b/test/simulator/pauli_circuit/test_assert_is_pauli_circuit.py
@@ -1,7 +1,7 @@
 import unittest
 
 from quantestpy import PauliCircuit
-from quantestpy.exceptions import QuantestPyTestCircuitError
+from quantestpy.simulator.exceptions import PauliCircuitError
 
 
 class TestAssertIsPauliCircuit(unittest.TestCase):
@@ -30,7 +30,7 @@ class TestAssertIsPauliCircuit(unittest.TestCase):
         expected_error_msg = \
             "circuit must be an instance of PauliCircuit class."
 
-        with self.assertRaises(QuantestPyTestCircuitError) as cm:
+        with self.assertRaises(PauliCircuitError) as cm:
             PauliCircuit._assert_is_pauli_circuit(circuit=circ)
 
         self.assertEqual(cm.exception.args[0], expected_error_msg)

--- a/test/simulator/quantestpy_circuit/test_add_gate.py
+++ b/test/simulator/quantestpy_circuit/test_add_gate.py
@@ -20,15 +20,15 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
     """
 
     def test_all_pass(self,):
-        test_circuit = QuantestPyCircuit(3)
-        test_circuit.add_gate(
+        qc = QuantestPyCircuit(3)
+        qc.add_gate(
             {"name": "h",
                 "target_qubit": [1],
                 "control_qubit": [],
                 "control_value": [],
                 "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x",
                 "target_qubit": [2],
                 "control_qubit": [0, 1],
@@ -49,20 +49,20 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
                 "parameter": []}
         ]
 
-        actual_gates = test_circuit._gates
+        actual_gates = qc._gates
 
         self.assertEqual(expected_gates, actual_gates)
 
     def test_all_pass_multi_target(self,):
-        test_circuit = QuantestPyCircuit(3)
-        test_circuit.add_gate(
+        qc = QuantestPyCircuit(3)
+        qc.add_gate(
             {"name": "x",
                 "target_qubit": [1, 2],
                 "control_qubit": [0],
                 "control_value": [1],
                 "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "h",
                 "target_qubit": [0, 1, 2],
                 "control_qubit": [],
@@ -83,16 +83,16 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
                 "parameter": []}
         ]
 
-        actual_gates = test_circuit._gates
+        actual_gates = qc._gates
 
         self.assertEqual(expected_gates, actual_gates)
 
     def test_index_range_in_target_qubit(self,):
-        test_circuit = QuantestPyCircuit(3)
+        qc = QuantestPyCircuit(3)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "x",
                      "target_qubit": [3],
                      "control_qubit": [],
@@ -105,18 +105,18 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
             expected_error_msg = \
                 "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "Index 3" \
-                + " in target_qubit out of range for test_circuit size 3.\n"
+                + " in target_qubit out of range for circuit size 3.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
 
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_index_type_in_target_qubit(self,):
-        test_circuit = QuantestPyCircuit(4)
+        qc = QuantestPyCircuit(4)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "h",
                      "target_qubit": [1.],
                      "control_qubit": [],
@@ -135,11 +135,11 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_index_range_in_control_qubit(self,):
-        test_circuit = QuantestPyCircuit(10)
+        qc = QuantestPyCircuit(10)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "x",
                      "target_qubit": [1],
                      "control_qubit": [2, 10],
@@ -152,18 +152,18 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
             expected_error_msg = \
                 "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "Index 10" \
-                + " in control_qubit out of range for test_circuit size 10.\n"
+                + " in control_qubit out of range for circuit size 10.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
 
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_index_type_in_control_qubit(self,):
-        test_circuit = QuantestPyCircuit(3)
+        qc = QuantestPyCircuit(3)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "x",
                      "target_qubit": [0],
                      "control_qubit": [1.2],
@@ -182,11 +182,11 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_value_range_in_control_value(self,):
-        test_circuit = QuantestPyCircuit(3)
+        qc = QuantestPyCircuit(3)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "x",
                      "target_qubit": [0],
                      "control_qubit": [1, 2],
@@ -207,11 +207,11 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_value_type_in_control_value(self,):
-        test_circuit = QuantestPyCircuit(3)
+        qc = QuantestPyCircuit(3)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "x",
                      "target_qubit": [0],
                      "control_qubit": [0, 2],
@@ -230,11 +230,11 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_target_qubit_empty(self,):
-        test_circuit = QuantestPyCircuit(5)
+        qc = QuantestPyCircuit(5)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "t",
                      "target_qubit": [],
                      "control_qubit": [],
@@ -254,11 +254,11 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
 
     def test_msg_from_duplicate_in_target_qubit(self,):
 
-        test_circuit = QuantestPyCircuit(5)
+        qc = QuantestPyCircuit(5)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "x",
                      "target_qubit": [0, 0, 2],
                      "control_qubit": [4],
@@ -278,11 +278,11 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
 
     def test_msg_from_duplicate_in_control_qubit(self,):
 
-        test_circuit = QuantestPyCircuit(5)
+        qc = QuantestPyCircuit(5)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "x",
                      "target_qubit": [0],
                      "control_qubit": [1, 2, 3, 4, 4],
@@ -302,11 +302,11 @@ class TestQuantestPyCircuitAddGate(unittest.TestCase):
 
     def test_msg_from_intersection_in_target_and_control_qubits(self,):
 
-        test_circuit = QuantestPyCircuit(5)
+        qc = QuantestPyCircuit(5)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                qc.add_gate(
                     {"name": "x",
                      "target_qubit": [0, 1, 2, 3],
                      "control_qubit": [3, 4],

--- a/test/simulator/quantestpy_circuit/test_add_gate.py
+++ b/test/simulator/quantestpy_circuit/test_add_gate.py
@@ -1,26 +1,26 @@
 import traceback
 import unittest
 
-from quantestpy import TestCircuit
-from quantestpy.exceptions import QuantestPyTestCircuitError
+from quantestpy import QuantestPyCircuit
+from quantestpy.simulator.exceptions import QuantestPyCircuitError
 
 
-class TestTestCircuitAddGate(unittest.TestCase):
+class TestQuantestPyCircuitAddGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_add_gate
-    ................
+    $ python -m unittest test.simulator.quantestpy_circuit.test_add_gate
+    ............
     ----------------------------------------------------------------------
-    Ran 16 tests in 0.001s
+    Ran 12 tests in 0.001s
 
     OK
     $
     """
 
     def test_all_pass(self,):
-        test_circuit = TestCircuit(3)
+        test_circuit = QuantestPyCircuit(3)
         test_circuit.add_gate(
             {"name": "h",
                 "target_qubit": [1],
@@ -54,7 +54,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
         self.assertEqual(expected_gates, actual_gates)
 
     def test_all_pass_multi_target(self,):
-        test_circuit = TestCircuit(3)
+        test_circuit = QuantestPyCircuit(3)
         test_circuit.add_gate(
             {"name": "x",
                 "target_qubit": [1, 2],
@@ -88,7 +88,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
         self.assertEqual(expected_gates, actual_gates)
 
     def test_index_range_in_target_qubit(self,):
-        test_circuit = TestCircuit(3)
+        test_circuit = QuantestPyCircuit(3)
 
         try:
             self.assertIsNotNone(
@@ -101,9 +101,10 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: Index 3" \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
+                + "Index 3" \
                 + " in target_qubit out of range for test_circuit size 3.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
@@ -111,7 +112,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_index_type_in_target_qubit(self,):
-        test_circuit = TestCircuit(4)
+        test_circuit = QuantestPyCircuit(4)
 
         try:
             self.assertIsNotNone(
@@ -124,9 +125,9 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "Index in target_qubit must be integer type.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
@@ -134,7 +135,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_index_range_in_control_qubit(self,):
-        test_circuit = TestCircuit(10)
+        test_circuit = QuantestPyCircuit(10)
 
         try:
             self.assertIsNotNone(
@@ -147,9 +148,10 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: Index 10" \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
+                + "Index 10" \
                 + " in control_qubit out of range for test_circuit size 10.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
@@ -157,7 +159,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_index_type_in_control_qubit(self,):
-        test_circuit = TestCircuit(3)
+        test_circuit = QuantestPyCircuit(3)
 
         try:
             self.assertIsNotNone(
@@ -170,9 +172,9 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "Index in control_qubit must be integer type.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
@@ -180,7 +182,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_value_range_in_control_value(self,):
-        test_circuit = TestCircuit(3)
+        test_circuit = QuantestPyCircuit(3)
 
         try:
             self.assertIsNotNone(
@@ -193,9 +195,10 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: Value 2" \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
+                + "Value 2" \
                 + " in control_value is not acceptable. " \
                 + "It must be either 0 or 1.\n"
 
@@ -204,7 +207,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_value_type_in_control_value(self,):
-        test_circuit = TestCircuit(3)
+        test_circuit = QuantestPyCircuit(3)
 
         try:
             self.assertIsNotNone(
@@ -217,9 +220,9 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "Value in control_value must be integer type.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
@@ -227,7 +230,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_target_qubit_empty(self,):
-        test_circuit = TestCircuit(5)
+        test_circuit = QuantestPyCircuit(5)
 
         try:
             self.assertIsNotNone(
@@ -240,105 +243,10 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "'target_qubit' must not an empty list.\n"
-
-            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
-
-            self.assertEqual(expected_error_msg, actual_error_msg)
-
-    def test_parameter_without_param(self,):
-        test_circuit = TestCircuit(1)
-
-        try:
-            self.assertIsNotNone(
-                test_circuit.add_gate(
-                    {"name": "x",
-                     "target_qubit": [0],
-                     "control_qubit": [],
-                     "control_value": [],
-                     "parameter": [1]}
-                )
-            )
-
-        except QuantestPyTestCircuitError as e:
-            expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
-                + "x gate must have " \
-                + "an empty list for 'parameter'.\n"
-
-            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
-
-            self.assertEqual(expected_error_msg, actual_error_msg)
-
-    def test_parameter_with_one_param(self,):
-        test_circuit = TestCircuit(1)
-
-        try:
-            self.assertIsNotNone(
-                test_circuit.add_gate(
-                    {"name": "p",
-                     "target_qubit": [0],
-                     "control_qubit": [],
-                     "control_value": [],
-                     "parameter": []}
-                )
-            )
-
-        except QuantestPyTestCircuitError as e:
-            expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
-                + "p gate must have a list containing " \
-                + "exactly 1 element for 'parameter'.\n"
-
-            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
-
-            self.assertEqual(expected_error_msg, actual_error_msg)
-
-    def test_parameter_with_four_param(self,):
-        test_circuit = TestCircuit(1)
-
-        try:
-            self.assertIsNotNone(
-                test_circuit.add_gate(
-                    {"name": "u",
-                     "target_qubit": [0],
-                     "control_qubit": [],
-                     "control_value": [],
-                     "parameter": []}
-                )
-            )
-
-        except QuantestPyTestCircuitError as e:
-            expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
-                + "u gate must have a list containing " \
-                + "exactly 4 elements for 'parameter'.\n"
-
-            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
-
-            self.assertEqual(expected_error_msg, actual_error_msg)
-
-    def test_value_type_in_parameter(self,):
-        test_circuit = TestCircuit(1)
-
-        try:
-            self.assertIsNotNone(
-                test_circuit.add_gate(
-                    {"name": "p",
-                     "target_qubit": [0],
-                     "control_qubit": [],
-                     "control_value": [],
-                     "parameter": ["a"]}
-                )
-            )
-
-        except QuantestPyTestCircuitError as e:
-            expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
-                + "Parameter(s) in p gate must be float or integer type.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
 
@@ -346,7 +254,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
 
     def test_msg_from_duplicate_in_target_qubit(self,):
 
-        test_circuit = TestCircuit(5)
+        test_circuit = QuantestPyCircuit(5)
 
         try:
             self.assertIsNotNone(
@@ -359,9 +267,9 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "Duplicate in target_qubit is not supported.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
@@ -370,7 +278,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
 
     def test_msg_from_duplicate_in_control_qubit(self,):
 
-        test_circuit = TestCircuit(5)
+        test_circuit = QuantestPyCircuit(5)
 
         try:
             self.assertIsNotNone(
@@ -383,9 +291,9 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "Duplicate in control_qubit is not supported.\n"
 
             actual_error_msg = traceback.format_exception_only(type(e), e)[0]
@@ -394,7 +302,7 @@ class TestTestCircuitAddGate(unittest.TestCase):
 
     def test_msg_from_intersection_in_target_and_control_qubits(self,):
 
-        test_circuit = TestCircuit(5)
+        test_circuit = QuantestPyCircuit(5)
 
         try:
             self.assertIsNotNone(
@@ -407,9 +315,9 @@ class TestTestCircuitAddGate(unittest.TestCase):
                 )
             )
 
-        except QuantestPyTestCircuitError as e:
+        except QuantestPyCircuitError as e:
             expected_error_msg = \
-                "quantestpy.exceptions.QuantestPyTestCircuitError: " \
+                "quantestpy.simulator.exceptions.QuantestPyCircuitError: " \
                 + "target_qubit [0, 1, 2, 3] and control_qubit [3, 4] have " \
                 + "intersection.\n"
 

--- a/test/simulator/state_vector_circuit/test_add_gate.py
+++ b/test/simulator/state_vector_circuit/test_add_gate.py
@@ -20,11 +20,11 @@ class TestStateVectorCircuitAddGate(unittest.TestCase):
     """
 
     def test_parameter_without_param(self,):
-        test_circuit = StateVectorCircuit(1)
+        svc = StateVectorCircuit(1)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                svc.add_gate(
                     {"name": "x",
                      "target_qubit": [0],
                      "control_qubit": [],
@@ -44,11 +44,11 @@ class TestStateVectorCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_parameter_with_one_param(self,):
-        test_circuit = StateVectorCircuit(1)
+        svc = StateVectorCircuit(1)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                svc.add_gate(
                     {"name": "p",
                      "target_qubit": [0],
                      "control_qubit": [],
@@ -68,11 +68,11 @@ class TestStateVectorCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_parameter_with_four_param(self,):
-        test_circuit = StateVectorCircuit(1)
+        svc = StateVectorCircuit(1)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                svc.add_gate(
                     {"name": "u",
                      "target_qubit": [0],
                      "control_qubit": [],
@@ -92,11 +92,11 @@ class TestStateVectorCircuitAddGate(unittest.TestCase):
             self.assertEqual(expected_error_msg, actual_error_msg)
 
     def test_value_type_in_parameter(self,):
-        test_circuit = StateVectorCircuit(1)
+        svc = StateVectorCircuit(1)
 
         try:
             self.assertIsNotNone(
-                test_circuit.add_gate(
+                svc.add_gate(
                     {"name": "p",
                      "target_qubit": [0],
                      "control_qubit": [],

--- a/test/simulator/state_vector_circuit/test_add_gate.py
+++ b/test/simulator/state_vector_circuit/test_add_gate.py
@@ -1,0 +1,115 @@
+import traceback
+import unittest
+
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.exceptions import StateVectorCircuitError
+
+
+class TestStateVectorCircuitAddGate(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.simulator.state_vector_circuit.test_add_gate
+    ................
+    ----------------------------------------------------------------------
+    Ran 16 tests in 0.001s
+
+    OK
+    $
+    """
+
+    def test_parameter_without_param(self,):
+        test_circuit = StateVectorCircuit(1)
+
+        try:
+            self.assertIsNotNone(
+                test_circuit.add_gate(
+                    {"name": "x",
+                     "target_qubit": [0],
+                     "control_qubit": [],
+                     "control_value": [],
+                     "parameter": [1]}
+                )
+            )
+
+        except StateVectorCircuitError as e:
+            expected_error_msg = \
+                "quantestpy.simulator.exceptions.StateVectorCircuitError: " \
+                + "x gate must have " \
+                + "an empty list for 'parameter'.\n"
+
+            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
+
+            self.assertEqual(expected_error_msg, actual_error_msg)
+
+    def test_parameter_with_one_param(self,):
+        test_circuit = StateVectorCircuit(1)
+
+        try:
+            self.assertIsNotNone(
+                test_circuit.add_gate(
+                    {"name": "p",
+                     "target_qubit": [0],
+                     "control_qubit": [],
+                     "control_value": [],
+                     "parameter": []}
+                )
+            )
+
+        except StateVectorCircuitError as e:
+            expected_error_msg = \
+                "quantestpy.simulator.exceptions.StateVectorCircuitError: " \
+                + "p gate must have a list containing " \
+                + "exactly 1 element for 'parameter'.\n"
+
+            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
+
+            self.assertEqual(expected_error_msg, actual_error_msg)
+
+    def test_parameter_with_four_param(self,):
+        test_circuit = StateVectorCircuit(1)
+
+        try:
+            self.assertIsNotNone(
+                test_circuit.add_gate(
+                    {"name": "u",
+                     "target_qubit": [0],
+                     "control_qubit": [],
+                     "control_value": [],
+                     "parameter": []}
+                )
+            )
+
+        except StateVectorCircuitError as e:
+            expected_error_msg = \
+                "quantestpy.simulator.exceptions.StateVectorCircuitError: " \
+                + "u gate must have a list containing " \
+                + "exactly 4 elements for 'parameter'.\n"
+
+            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
+
+            self.assertEqual(expected_error_msg, actual_error_msg)
+
+    def test_value_type_in_parameter(self,):
+        test_circuit = StateVectorCircuit(1)
+
+        try:
+            self.assertIsNotNone(
+                test_circuit.add_gate(
+                    {"name": "p",
+                     "target_qubit": [0],
+                     "control_qubit": [],
+                     "control_value": [],
+                     "parameter": ["a"]}
+                )
+            )
+
+        except StateVectorCircuitError as e:
+            expected_error_msg = \
+                "quantestpy.simulator.exceptions.StateVectorCircuitError: " \
+                + "Parameter(s) in p gate must be float or integer type.\n"
+
+            actual_error_msg = traceback.format_exception_only(type(e), e)[0]
+
+            self.assertEqual(expected_error_msg, actual_error_msg)

--- a/test/simulator/state_vector_circuit/test_ch_gate.py
+++ b/test/simulator/state_vector_circuit/test_ch_gate.py
@@ -2,16 +2,16 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _H
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _H
 
 
-class TestTestCircuitCHGate(unittest.TestCase):
+class TestStateVectorCircuitCHGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_ch_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_ch_gate
     ........
     ----------------------------------------------------------------------
     Ran 7 tests in 0.009s
@@ -21,7 +21,7 @@ class TestTestCircuitCHGate(unittest.TestCase):
     """
 
     def test_ch_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _H, control_qubit=[0], target_qubit=[1], control_value=[1]
         )
@@ -35,7 +35,7 @@ class TestTestCircuitCHGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_ch_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _H, control_qubit=[0], target_qubit=[1], control_value=[1]
@@ -51,7 +51,7 @@ class TestTestCircuitCHGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_ch_flip_control_target(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _H, control_qubit=[1], target_qubit=[0], control_value=[1]
         )
@@ -67,7 +67,7 @@ class TestTestCircuitCHGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_ch_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _H, control_qubit=[0], target_qubit=[2], control_value=[1]
@@ -103,7 +103,7 @@ class TestTestCircuitCHGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_ch_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _H, control_qubit=[0], target_qubit=[1], control_value=[0]
         )
@@ -117,7 +117,7 @@ class TestTestCircuitCHGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_ch_multiple_controls(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _H,
             control_qubit=[0, 1], target_qubit=[2], control_value=[1, 1]
@@ -139,12 +139,12 @@ class TestTestCircuitCHGate(unittest.TestCase):
 
     def test_ch_multiple_targets(self,):
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
             _H, control_qubit=[0], target_qubit=[1, 2], control_value=[1]
         )
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
             _H, control_qubit=[0], target_qubit=[1], control_value=[1]
         )

--- a/test/simulator/state_vector_circuit/test_cp_gate.py
+++ b/test/simulator/state_vector_circuit/test_cp_gate.py
@@ -2,16 +2,16 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _rz
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _p
 
 
-class TestTestCircuitCRZGate(unittest.TestCase):
+class TestStateVectorCircuitCPGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_crz_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_cp_gate
     ........
     ----------------------------------------------------------------------
     Ran 7 tests in 0.007s
@@ -20,61 +20,61 @@ class TestTestCircuitCRZGate(unittest.TestCase):
     $
     """
 
-    def test_crz_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_cp_regular_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
             [0, 1, 0, 0],
-            [0, 0, np.exp(-1j*lambda_/2), 0],
-            [0, 0, 0, np.exp(1j*lambda_/2)]])
+            [0, 0, 1, 0],
+            [0, 0, 0, np.exp(1j*lambda_)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crz_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_cp_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
-            [0, np.exp(-1j*lambda_/2), 0, 0],
+            [0, 1, 0, 0],
             [0, 0, 1, 0],
-            [0, 0, 0, np.exp(1j*lambda_/2)]])
+            [0, 0, 0, np.exp(1j*lambda_)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crz_flip_control_target(self,):
-        circ = TestCircuit(2)
+    def test_cp_flip_control_target(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[1], target_qubit=[0], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
-            [0, np.exp(-1j*lambda_/2), 0, 0],
+            [0, 1, 0, 0],
             [0, 0, 1, 0],
-            [0, 0, 0, np.exp(1j*lambda_/2)]])
+            [0, 0, 0, np.exp(1j*lambda_)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crz_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+    def test_cp_three_qubits_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(3)
         lambda_ = np.pi/8
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[0], target_qubit=[2], control_value=[1])
 
         # this is qiskit's output
@@ -83,16 +83,16 @@ class TestTestCircuitCRZGate(unittest.TestCase):
               0. + 0.j, 0. + 0.j,
               0. + 0.j, 0. + 0.j,
               0. + 0.j, 0. + 0.j],
-             [0. + 0.j, 0.98078528-0.19509032j,
+             [0. + 0.j, 1. + 0.j,
                 0. + 0.j, 0. + 0.j,
-                0. + 0.j, 0. + 0.j,
-              0. + 0.j, 0. + 0.j],
-             [0. + 0.j, 0. + 0.j,
-                1. + 0.j, 0. + 0.j,
                 0. + 0.j, 0. + 0.j,
                 0. + 0.j, 0. + 0.j],
                 [0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0.98078528-0.19509032j,
+                 1. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0. + 0.j],
+                [0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 1. + 0.j,
                  0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j],
                 [0. + 0.j, 0. + 0.j,
@@ -101,7 +101,7 @@ class TestTestCircuitCRZGate(unittest.TestCase):
                  0. + 0.j, 0. + 0.j],
                 [0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0.98078528+0.19509032j,
+                 0. + 0.j, 0.92387953+0.38268343j,
                  0. + 0.j, 0. + 0.j],
                 [0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j,
@@ -110,32 +110,32 @@ class TestTestCircuitCRZGate(unittest.TestCase):
                 [0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0.98078528+0.19509032j]])
+                 0. + 0.j, 0.92387953+0.38268343j]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crz_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+    def test_cp_control_value_is_zero(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[0])
 
         expected_gate = np.array([
-            [np.exp(-1j*lambda_/2), 0, 0, 0],
-            [0, np.exp(1j*lambda_/2), 0, 0],
+            [1, 0, 0, 0],
+            [0, np.exp(1j*lambda_), 0, 0],
             [0, 0, 1, 0],
             [0, 0, 0, 1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crz_multiple_controls(self,):
-        circ = TestCircuit(3)
+    def test_cp_multiple_controls(self,):
+        circ = StateVectorCircuit(3)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[0, 1], target_qubit=[2], control_value=[1, 1])
 
         expected_gate = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
@@ -144,28 +144,26 @@ class TestTestCircuitCRZGate(unittest.TestCase):
                                   [0, 0, 0, 1, 0, 0, 0, 0],
                                   [0, 0, 0, 0, 1, 0, 0, 0],
                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                  [0, 0, 0, 0, 0, 0,
-                                   np.exp(-1j*lambda_/2), 0],
-                                  [0, 0, 0, 0, 0, 0,
-                                   0, np.exp(1j*lambda_/2)]])
+                                  [0, 0, 0, 0, 0, 0, 1, 0],
+                                  [0, 0, 0, 0, 0, 0, 0, np.exp(1j*lambda_)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crz_multiple_targets(self,):
+    def test_cp_multiple_targets(self,):
         lambda_ = np.pi/8
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[0], target_qubit=[1, 2], control_value=[1])
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
         gate_1_1 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rz([lambda_]),
+            _p([lambda_]),
             control_qubit=[0], target_qubit=[2], control_value=[1])
 
         self.assertIsNone(

--- a/test/simulator/state_vector_circuit/test_crx_gate.py
+++ b/test/simulator/state_vector_circuit/test_crx_gate.py
@@ -2,132 +2,140 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _ry
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _rx
 
 
-class TestTestCircuitCRYGate(unittest.TestCase):
+class TestStateVectorCircuitCRXGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_cry_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_crx_gate
     ........
     ----------------------------------------------------------------------
-    Ran 7 tests in 0.006s
+    Ran 7 tests in 0.007s
 
     OK
     $
     """
 
-    def test_cry_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_crx_regular_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
             [0, 1, 0, 0],
-            [0, 0, np.cos(lambda_/2), -np.sin(lambda_/2)],
-            [0, 0, np.sin(lambda_/2), np.cos(lambda_/2)]])
+            [0, 0, np.cos(lambda_/2), -1j*np.sin(lambda_/2)],
+            [0, 0, -1j*np.sin(lambda_/2), np.cos(lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cry_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_crx_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
-            [0, np.cos(lambda_/2), 0, -np.sin(lambda_/2)],
+            [0, np.cos(lambda_/2), 0, -1j*np.sin(lambda_/2)],
             [0, 0, 1, 0],
-            [0, np.sin(lambda_/2), 0, np.cos(lambda_/2)]])
+            [0, - 1j*np.sin(lambda_/2), 0, np.cos(lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cry_flip_control_target(self,):
-        circ = TestCircuit(2)
+    def test_crx_flip_control_target(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[1], target_qubit=[0], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
-            [0, np.cos(lambda_/2), 0, -np.sin(lambda_/2)],
+            [0, np.cos(lambda_/2), 0, -1j*np.sin(lambda_/2)],
             [0, 0, 1, 0],
-            [0, np.sin(lambda_/2), 0, np.cos(lambda_/2)]])
+            [0, - 1j*np.sin(lambda_/2), 0, np.cos(lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cry_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+    def test_crx_three_qubits_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(3)
         lambda_ = np.pi/8
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[0], target_qubit=[2], control_value=[1])
 
         # this is qiskit's output
         expected_gate = np.array(
-            [[1. + 0.j,  0. + 0.j,  0. + 0.j,
-              0. + 0.j,  0. + 0.j,  0. + 0.j,
-              0. + 0.j,  0. + 0.j],
-             [0. + 0.j,  0.98078528+0.j,  0. + 0.j,
-                0. + 0.j,  0. + 0.j, -0.19509032+0.j,
-                0. + 0.j,  0. + 0.j],
-                [0. + 0.j,  0. + 0.j,  1. + 0.j,
-                 0. + 0.j,  0. + 0.j,  0. + 0.j,
-                 0. + 0.j,  0. + 0.j],
-                [0. + 0.j,  0. + 0.j,  0. + 0.j,
-                 0.98078528+0.j,  0. + 0.j,  0. + 0.j,
-                 0. + 0.j, -0.19509032+0.j],
-                [0. + 0.j,  0. + 0.j,  0. + 0.j,
-                 0. + 0.j,  1. + 0.j,  0. + 0.j,
-                 0. + 0.j,  0. + 0.j],
-                [0. + 0.j,  0.19509032+0.j,  0. + 0.j,
-                 0. + 0.j,  0. + 0.j,  0.98078528+0.j,
-                 0. + 0.j,  0. + 0.j],
-                [0. + 0.j,  0. + 0.j,  0. + 0.j,
-                 0. + 0.j,  0. + 0.j,  0. + 0.j,
-                 1. + 0.j,  0. + 0.j],
-                [0. + 0.j,  0. + 0.j,  0. + 0.j,
-                 0.19509032+0.j,  0. + 0.j,  0. + 0.j,
-                 0. + 0.j,  0.98078528+0.j]])
+            [[1. + 0.j, 0. + 0.j,
+              0. + 0.j, 0. + 0.j,
+              0. + 0.j, 0. + 0.j,
+              0. + 0.j, 0. + 0.j],
+             [0. + 0.j, 0.98078528+0.j,
+                0. + 0.j, 0. + 0.j,
+                0. + 0.j, 0. - 0.19509032j,
+              0. + 0.j, 0. + 0.j],
+             [0. + 0.j, 0. + 0.j,
+                1. + 0.j, 0. + 0.j,
+                0. + 0.j, 0. + 0.j,
+                0. + 0.j, 0. + 0.j],
+                [0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0.98078528+0.j,
+                 0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0. - 0.19509032j],
+                [0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0. + 0.j,
+                 1. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0. + 0.j],
+                [0. + 0.j, 0. - 0.19509032j,
+                 0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0.98078528+0.j,
+                 0. + 0.j, 0. + 0.j],
+                [0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0. + 0.j,
+                 1. + 0.j, 0. + 0.j],
+                [0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0. - 0.19509032j,
+                 0. + 0.j, 0. + 0.j,
+                 0. + 0.j, 0.98078528+0.j]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cry_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+    def test_crx_control_value_is_zero(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[0])
 
         expected_gate = np.array([
-            [np.cos(lambda_/2), -np.sin(lambda_/2), 0, 0],
-            [np.sin(lambda_/2), np.cos(lambda_/2), 0, 0],
+            [np.cos(lambda_/2), -1j*np.sin(lambda_/2), 0, 0],
+            [-1j*np.sin(lambda_/2), np.cos(lambda_/2), 0, 0],
             [0, 0, 1, 0],
             [0, 0, 0, 1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cry_multiple_controls(self,):
-        circ = TestCircuit(3)
+    def test_crx_multiple_controls(self,):
+        circ = StateVectorCircuit(3)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[0, 1], target_qubit=[2], control_value=[1, 1])
 
         expected_gate = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
@@ -137,27 +145,27 @@ class TestTestCircuitCRYGate(unittest.TestCase):
                                   [0, 0, 0, 0, 1, 0, 0, 0],
                                   [0, 0, 0, 0, 0, 1, 0, 0],
                                   [0, 0, 0, 0, 0, 0,
-                                   np.cos(lambda_/2), -np.sin(lambda_/2)],
+                                   np.cos(lambda_/2), -1j*np.sin(lambda_/2)],
                                   [0, 0, 0, 0, 0, 0,
-                                   np.sin(lambda_/2), np.cos(lambda_/2)]])
+                                   -1j*np.sin(lambda_/2), np.cos(lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cry_multiple_targets(self,):
+    def test_crx_multiple_targets(self,):
         lambda_ = np.pi/8
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[0], target_qubit=[1, 2], control_value=[1])
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
         gate_1_1 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _ry([lambda_]),
+            _rx([lambda_]),
             control_qubit=[0], target_qubit=[2], control_value=[1])
 
         self.assertIsNone(

--- a/test/simulator/state_vector_circuit/test_cry_gate.py
+++ b/test/simulator/state_vector_circuit/test_cry_gate.py
@@ -2,140 +2,132 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _rx
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _ry
 
 
-class TestTestCircuitCRXGate(unittest.TestCase):
+class TestStateVectorCircuitCRYGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_crx_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_cry_gate
     ........
     ----------------------------------------------------------------------
-    Ran 7 tests in 0.007s
+    Ran 7 tests in 0.006s
 
     OK
     $
     """
 
-    def test_crx_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_cry_regular_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
             [0, 1, 0, 0],
-            [0, 0, np.cos(lambda_/2), -1j*np.sin(lambda_/2)],
-            [0, 0, -1j*np.sin(lambda_/2), np.cos(lambda_/2)]])
+            [0, 0, np.cos(lambda_/2), -np.sin(lambda_/2)],
+            [0, 0, np.sin(lambda_/2), np.cos(lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crx_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_cry_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
-            [0, np.cos(lambda_/2), 0, -1j*np.sin(lambda_/2)],
+            [0, np.cos(lambda_/2), 0, -np.sin(lambda_/2)],
             [0, 0, 1, 0],
-            [0, - 1j*np.sin(lambda_/2), 0, np.cos(lambda_/2)]])
+            [0, np.sin(lambda_/2), 0, np.cos(lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crx_flip_control_target(self,):
-        circ = TestCircuit(2)
+    def test_cry_flip_control_target(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[1], target_qubit=[0], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
-            [0, np.cos(lambda_/2), 0, -1j*np.sin(lambda_/2)],
+            [0, np.cos(lambda_/2), 0, -np.sin(lambda_/2)],
             [0, 0, 1, 0],
-            [0, - 1j*np.sin(lambda_/2), 0, np.cos(lambda_/2)]])
+            [0, np.sin(lambda_/2), 0, np.cos(lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crx_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+    def test_cry_three_qubits_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(3)
         lambda_ = np.pi/8
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[0], target_qubit=[2], control_value=[1])
 
         # this is qiskit's output
         expected_gate = np.array(
-            [[1. + 0.j, 0. + 0.j,
-              0. + 0.j, 0. + 0.j,
-              0. + 0.j, 0. + 0.j,
-              0. + 0.j, 0. + 0.j],
-             [0. + 0.j, 0.98078528+0.j,
-                0. + 0.j, 0. + 0.j,
-                0. + 0.j, 0. - 0.19509032j,
-              0. + 0.j, 0. + 0.j],
-             [0. + 0.j, 0. + 0.j,
-                1. + 0.j, 0. + 0.j,
-                0. + 0.j, 0. + 0.j,
-                0. + 0.j, 0. + 0.j],
-                [0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0.98078528+0.j,
-                 0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0. - 0.19509032j],
-                [0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0. + 0.j,
-                 1. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0. + 0.j],
-                [0. + 0.j, 0. - 0.19509032j,
-                 0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0.98078528+0.j,
-                 0. + 0.j, 0. + 0.j],
-                [0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0. + 0.j,
-                 1. + 0.j, 0. + 0.j],
-                [0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0. - 0.19509032j,
-                 0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0.98078528+0.j]])
+            [[1. + 0.j,  0. + 0.j,  0. + 0.j,
+              0. + 0.j,  0. + 0.j,  0. + 0.j,
+              0. + 0.j,  0. + 0.j],
+             [0. + 0.j,  0.98078528+0.j,  0. + 0.j,
+                0. + 0.j,  0. + 0.j, -0.19509032+0.j,
+                0. + 0.j,  0. + 0.j],
+                [0. + 0.j,  0. + 0.j,  1. + 0.j,
+                 0. + 0.j,  0. + 0.j,  0. + 0.j,
+                 0. + 0.j,  0. + 0.j],
+                [0. + 0.j,  0. + 0.j,  0. + 0.j,
+                 0.98078528+0.j,  0. + 0.j,  0. + 0.j,
+                 0. + 0.j, -0.19509032+0.j],
+                [0. + 0.j,  0. + 0.j,  0. + 0.j,
+                 0. + 0.j,  1. + 0.j,  0. + 0.j,
+                 0. + 0.j,  0. + 0.j],
+                [0. + 0.j,  0.19509032+0.j,  0. + 0.j,
+                 0. + 0.j,  0. + 0.j,  0.98078528+0.j,
+                 0. + 0.j,  0. + 0.j],
+                [0. + 0.j,  0. + 0.j,  0. + 0.j,
+                 0. + 0.j,  0. + 0.j,  0. + 0.j,
+                 1. + 0.j,  0. + 0.j],
+                [0. + 0.j,  0. + 0.j,  0. + 0.j,
+                 0.19509032+0.j,  0. + 0.j,  0. + 0.j,
+                 0. + 0.j,  0.98078528+0.j]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crx_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+    def test_cry_control_value_is_zero(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[0])
 
         expected_gate = np.array([
-            [np.cos(lambda_/2), -1j*np.sin(lambda_/2), 0, 0],
-            [-1j*np.sin(lambda_/2), np.cos(lambda_/2), 0, 0],
+            [np.cos(lambda_/2), -np.sin(lambda_/2), 0, 0],
+            [np.sin(lambda_/2), np.cos(lambda_/2), 0, 0],
             [0, 0, 1, 0],
             [0, 0, 0, 1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crx_multiple_controls(self,):
-        circ = TestCircuit(3)
+    def test_cry_multiple_controls(self,):
+        circ = StateVectorCircuit(3)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[0, 1], target_qubit=[2], control_value=[1, 1])
 
         expected_gate = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
@@ -145,27 +137,27 @@ class TestTestCircuitCRXGate(unittest.TestCase):
                                   [0, 0, 0, 0, 1, 0, 0, 0],
                                   [0, 0, 0, 0, 0, 1, 0, 0],
                                   [0, 0, 0, 0, 0, 0,
-                                   np.cos(lambda_/2), -1j*np.sin(lambda_/2)],
+                                   np.cos(lambda_/2), -np.sin(lambda_/2)],
                                   [0, 0, 0, 0, 0, 0,
-                                   -1j*np.sin(lambda_/2), np.cos(lambda_/2)]])
+                                   np.sin(lambda_/2), np.cos(lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_crx_multiple_targets(self,):
+    def test_cry_multiple_targets(self,):
         lambda_ = np.pi/8
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[0], target_qubit=[1, 2], control_value=[1])
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
         gate_1_1 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _rx([lambda_]),
+            _ry([lambda_]),
             control_qubit=[0], target_qubit=[2], control_value=[1])
 
         self.assertIsNone(

--- a/test/simulator/state_vector_circuit/test_crz_gate.py
+++ b/test/simulator/state_vector_circuit/test_crz_gate.py
@@ -2,16 +2,16 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _p
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _rz
 
 
-class TestTestCircuitCPGate(unittest.TestCase):
+class TestStateVectorCircuitCRZGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_cp_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_crz_gate
     ........
     ----------------------------------------------------------------------
     Ran 7 tests in 0.007s
@@ -20,61 +20,61 @@ class TestTestCircuitCPGate(unittest.TestCase):
     $
     """
 
-    def test_cp_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_crz_regular_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
             [0, 1, 0, 0],
-            [0, 0, 1, 0],
-            [0, 0, 0, np.exp(1j*lambda_)]])
+            [0, 0, np.exp(-1j*lambda_/2), 0],
+            [0, 0, 0, np.exp(1j*lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cp_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_crz_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
-            [0, 1, 0, 0],
+            [0, np.exp(-1j*lambda_/2), 0, 0],
             [0, 0, 1, 0],
-            [0, 0, 0, np.exp(1j*lambda_)]])
+            [0, 0, 0, np.exp(1j*lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cp_flip_control_target(self,):
-        circ = TestCircuit(2)
+    def test_crz_flip_control_target(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[1], target_qubit=[0], control_value=[1])
 
         expected_gate = np.array([
             [1, 0, 0, 0],
-            [0, 1, 0, 0],
+            [0, np.exp(-1j*lambda_/2), 0, 0],
             [0, 0, 1, 0],
-            [0, 0, 0, np.exp(1j*lambda_)]])
+            [0, 0, 0, np.exp(1j*lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cp_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+    def test_crz_three_qubits_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(3)
         lambda_ = np.pi/8
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[0], target_qubit=[2], control_value=[1])
 
         # this is qiskit's output
@@ -83,16 +83,16 @@ class TestTestCircuitCPGate(unittest.TestCase):
               0. + 0.j, 0. + 0.j,
               0. + 0.j, 0. + 0.j,
               0. + 0.j, 0. + 0.j],
-             [0. + 0.j, 1. + 0.j,
+             [0. + 0.j, 0.98078528-0.19509032j,
                 0. + 0.j, 0. + 0.j,
+                0. + 0.j, 0. + 0.j,
+              0. + 0.j, 0. + 0.j],
+             [0. + 0.j, 0. + 0.j,
+                1. + 0.j, 0. + 0.j,
                 0. + 0.j, 0. + 0.j,
                 0. + 0.j, 0. + 0.j],
                 [0. + 0.j, 0. + 0.j,
-                 1. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0. + 0.j],
-                [0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 1. + 0.j,
+                 0. + 0.j, 0.98078528-0.19509032j,
                  0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j],
                 [0. + 0.j, 0. + 0.j,
@@ -101,7 +101,7 @@ class TestTestCircuitCPGate(unittest.TestCase):
                  0. + 0.j, 0. + 0.j],
                 [0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0.92387953+0.38268343j,
+                 0. + 0.j, 0.98078528+0.19509032j,
                  0. + 0.j, 0. + 0.j],
                 [0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j,
@@ -110,32 +110,32 @@ class TestTestCircuitCPGate(unittest.TestCase):
                 [0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j,
                  0. + 0.j, 0. + 0.j,
-                 0. + 0.j, 0.92387953+0.38268343j]])
+                 0. + 0.j, 0.98078528+0.19509032j]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cp_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+    def test_crz_control_value_is_zero(self,):
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[0])
 
         expected_gate = np.array([
-            [1, 0, 0, 0],
-            [0, np.exp(1j*lambda_), 0, 0],
+            [np.exp(-1j*lambda_/2), 0, 0, 0],
+            [0, np.exp(1j*lambda_/2), 0, 0],
             [0, 0, 1, 0],
             [0, 0, 0, 1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cp_multiple_controls(self,):
-        circ = TestCircuit(3)
+    def test_crz_multiple_controls(self,):
+        circ = StateVectorCircuit(3)
         lambda_ = np.pi/8
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[0, 1], target_qubit=[2], control_value=[1, 1])
 
         expected_gate = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
@@ -144,26 +144,28 @@ class TestTestCircuitCPGate(unittest.TestCase):
                                   [0, 0, 0, 1, 0, 0, 0, 0],
                                   [0, 0, 0, 0, 1, 0, 0, 0],
                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 1, 0],
-                                  [0, 0, 0, 0, 0, 0, 0, np.exp(1j*lambda_)]])
+                                  [0, 0, 0, 0, 0, 0,
+                                   np.exp(-1j*lambda_/2), 0],
+                                  [0, 0, 0, 0, 0, 0,
+                                   0, np.exp(1j*lambda_/2)]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cp_multiple_targets(self,):
+    def test_crz_multiple_targets(self,):
         lambda_ = np.pi/8
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[0], target_qubit=[1, 2], control_value=[1])
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[0], target_qubit=[1], control_value=[1])
         gate_1_1 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _p([lambda_]),
+            _rz([lambda_]),
             control_qubit=[0], target_qubit=[2], control_value=[1])
 
         self.assertIsNone(

--- a/test/simulator/state_vector_circuit/test_cu_gate.py
+++ b/test/simulator/state_vector_circuit/test_cu_gate.py
@@ -2,16 +2,16 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _u
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _u
 
 
-class TestTestCircuitCUGate(unittest.TestCase):
+class TestStateVectorCircuitCUGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_cu_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_cu_gate
     ........
     ----------------------------------------------------------------------
     Ran 7 tests in 0.007s
@@ -21,7 +21,7 @@ class TestTestCircuitCUGate(unittest.TestCase):
     """
 
     def test_cu_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
 
         theta = np.pi/4
         phi = np.pi/8
@@ -43,7 +43,7 @@ class TestTestCircuitCUGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cu_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ._from_right_to_left_for_qubit_ids = True
 
         theta = np.pi/4
@@ -66,7 +66,7 @@ class TestTestCircuitCUGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cu_flip_control_target(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
 
         theta = np.pi/4
         phi = np.pi/8
@@ -88,7 +88,7 @@ class TestTestCircuitCUGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cu_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         circ._from_right_to_left_for_qubit_ids = True
 
         theta = np.pi/4
@@ -139,7 +139,7 @@ class TestTestCircuitCUGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cu_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
 
         theta = np.pi/4
         phi = np.pi/8
@@ -161,7 +161,7 @@ class TestTestCircuitCUGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cu_multiple_controls(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
 
         theta = np.pi/4
         phi = np.pi/8
@@ -193,12 +193,12 @@ class TestTestCircuitCUGate(unittest.TestCase):
         lambda_ = np.pi/16
         gamma = 0
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
             _u([theta, phi, lambda_, gamma]),
             control_qubit=[0], target_qubit=[1, 2], control_value=[1])
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
             _u([theta, phi, lambda_, gamma]),
             control_qubit=[0], target_qubit=[1], control_value=[1])

--- a/test/simulator/state_vector_circuit/test_cx_gate.py
+++ b/test/simulator/state_vector_circuit/test_cx_gate.py
@@ -2,16 +2,16 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _X
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _X
 
 
-class TestTestCircuitCXGate(unittest.TestCase):
+class TestStateVectorCircuitCXGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_cx_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_cx_gate
     ........
     ----------------------------------------------------------------------
     Ran 8 tests in 0.009s
@@ -21,7 +21,7 @@ class TestTestCircuitCXGate(unittest.TestCase):
     """
 
     def test_cx_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X, control_qubit=[0], target_qubit=[1], control_value=[1]
         )
@@ -35,7 +35,7 @@ class TestTestCircuitCXGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cx_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X, control_qubit=[0], target_qubit=[1], control_value=[1]
@@ -50,7 +50,7 @@ class TestTestCircuitCXGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cx_flip_control_target(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X, control_qubit=[1], target_qubit=[0], control_value=[1]
         )
@@ -64,7 +64,7 @@ class TestTestCircuitCXGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cx_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X, control_qubit=[0], target_qubit=[2], control_value=[1]
@@ -85,7 +85,7 @@ class TestTestCircuitCXGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_cx_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X, control_qubit=[0], target_qubit=[1], control_value=[0]
         )
@@ -99,7 +99,7 @@ class TestTestCircuitCXGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_toffoli(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X,
             control_qubit=[0, 1], target_qubit=[2], control_value=[1, 1])
@@ -117,7 +117,7 @@ class TestTestCircuitCXGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_toffoli_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X,
@@ -139,12 +139,12 @@ class TestTestCircuitCXGate(unittest.TestCase):
 
     def test_cx_multiple_targets(self,):
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X, control_qubit=[0], target_qubit=[1, 2], control_value=[1]
         )
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
             _X, control_qubit=[0], target_qubit=[1], control_value=[1]
         )

--- a/test/simulator/state_vector_circuit/test_cy_gate.py
+++ b/test/simulator/state_vector_circuit/test_cy_gate.py
@@ -2,106 +2,109 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _Z
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _Y
 
 
-class TestTestCircuitCZGate(unittest.TestCase):
+class TestStateVectorCircuitCYGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_cz_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_cy_gate
     ........
     ----------------------------------------------------------------------
-    Ran 7 tests in 0.007s
+    Ran 7 tests in 0.008s
 
     OK
     $
     """
 
-    def test_cz_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_cy_regular_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z, control_qubit=[0], target_qubit=[1], control_value=[1]
+            _Y, control_qubit=[0], target_qubit=[1], control_value=[1]
         )
 
         expected_gate = np.array([[1, 0, 0, 0],
                                   [0, 1, 0, 0],
-                                  [0, 0, 1, 0],
-                                  [0, 0, 0, -1]])
+                                  [0, 0, 0, -1j],
+                                  [0, 0, 1j, 0]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cz_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_cy_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z, control_qubit=[0], target_qubit=[1], control_value=[1]
+            _Y, control_qubit=[0], target_qubit=[1], control_value=[1]
         )
-
-        expected_gate = np.array([[1, 0, 0, 0],
-                                  [0, 1, 0, 0],
-                                  [0, 0, 1, 0],
-                                  [0, 0, 0, -1]])
+        # this is qiskit's output
+        expected_gate = np.array([
+            [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+            [0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j],
+            [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
+            [0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cz_flip_control_target(self,):
-        circ = TestCircuit(2)
+    def test_cy_flip_control_target(self,):
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z, control_qubit=[1], target_qubit=[0], control_value=[1]
+            _Y, control_qubit=[1], target_qubit=[0], control_value=[1]
         )
 
-        expected_gate = np.array([[1, 0, 0, 0],
-                                  [0, 1, 0, 0],
-                                  [0, 0, 1, 0],
-                                  [0, 0, 0, -1]])
+        # this is qiskit's output
+        expected_gate = np.array([
+            [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+            [0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j],
+            [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
+            [0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cz_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+    def test_cy_three_qubits_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(3)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z, control_qubit=[0], target_qubit=[2], control_value=[1]
+            _Y, control_qubit=[0], target_qubit=[2], control_value=[1]
         )
 
         # this is qiskit's output
         expected_gate = np.array([
             [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-            [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j, 0.+0.j],
             [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-            [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j],
             [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, -1.+0.j, 0.+0.j, 0.+0.j],
+            [0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
             [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
-            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, -1.+0.j]])
+            [0.+0.j, 0.+0.j, 0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cz_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+    def test_cy_control_value_is_zero(self,):
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z, control_qubit=[0], target_qubit=[1], control_value=[0]
+            _Y, control_qubit=[0], target_qubit=[1], control_value=[0]
         )
 
-        expected_gate = np.array([[1, 0, 0, 0],
-                                  [0, -1, 0, 0],
+        expected_gate = np.array([[0, -1j, 0, 0],
+                                  [1j, 0, 0, 0],
                                   [0, 0, 1, 0],
                                   [0, 0, 0, 1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cz_multiple_controls(self,):
-        circ = TestCircuit(3)
+    def test_cy_multiple_controls(self,):
+        circ = StateVectorCircuit(3)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z,
+            _Y,
             control_qubit=[0, 1], target_qubit=[2], control_value=[1, 1])
 
         expected_gate = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
@@ -110,25 +113,25 @@ class TestTestCircuitCZGate(unittest.TestCase):
                                   [0, 0, 0, 1, 0, 0, 0, 0],
                                   [0, 0, 0, 0, 1, 0, 0, 0],
                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 1, 0],
-                                  [0, 0, 0, 0, 0, 0, 0, -1]])
+                                  [0, 0, 0, 0, 0, 0, 0, -1j],
+                                  [0, 0, 0, 0, 0, 0, 1j, 0]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cz_multiple_targets(self,):
+    def test_cy_multiple_targets(self,):
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z, control_qubit=[0], target_qubit=[1, 2], control_value=[1]
+            _Y, control_qubit=[0], target_qubit=[1, 2], control_value=[1]
         )
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z, control_qubit=[0], target_qubit=[1], control_value=[1]
+            _Y, control_qubit=[0], target_qubit=[1], control_value=[1]
         )
         gate_1_1 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Z, control_qubit=[0], target_qubit=[2], control_value=[1]
+            _Y, control_qubit=[0], target_qubit=[2], control_value=[1]
         )
 
         self.assertIsNone(

--- a/test/simulator/state_vector_circuit/test_cz_gate.py
+++ b/test/simulator/state_vector_circuit/test_cz_gate.py
@@ -2,109 +2,106 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
-from quantestpy.test_circuit import _Y
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator.state_vector_circuit import _Z
 
 
-class TestTestCircuitCYGate(unittest.TestCase):
+class TestStateVectorCircuitCZGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_cy_gate
+    $ python -m unittest test.simulator.state_vector_circuit.test_cz_gate
     ........
     ----------------------------------------------------------------------
-    Ran 7 tests in 0.008s
+    Ran 7 tests in 0.007s
 
     OK
     $
     """
 
-    def test_cy_regular_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_cz_regular_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y, control_qubit=[0], target_qubit=[1], control_value=[1]
+            _Z, control_qubit=[0], target_qubit=[1], control_value=[1]
         )
 
         expected_gate = np.array([[1, 0, 0, 0],
                                   [0, 1, 0, 0],
-                                  [0, 0, 0, -1j],
-                                  [0, 0, 1j, 0]])
+                                  [0, 0, 1, 0],
+                                  [0, 0, 0, -1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cy_qiskit_qubit_order(self,):
-        circ = TestCircuit(2)
+    def test_cz_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(2)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y, control_qubit=[0], target_qubit=[1], control_value=[1]
+            _Z, control_qubit=[0], target_qubit=[1], control_value=[1]
         )
-        # this is qiskit's output
-        expected_gate = np.array([
-            [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-            [0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j],
-            [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
-            [0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j]])
+
+        expected_gate = np.array([[1, 0, 0, 0],
+                                  [0, 1, 0, 0],
+                                  [0, 0, 1, 0],
+                                  [0, 0, 0, -1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cy_flip_control_target(self,):
-        circ = TestCircuit(2)
+    def test_cz_flip_control_target(self,):
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y, control_qubit=[1], target_qubit=[0], control_value=[1]
+            _Z, control_qubit=[1], target_qubit=[0], control_value=[1]
         )
 
-        # this is qiskit's output
-        expected_gate = np.array([
-            [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-            [0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j],
-            [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
-            [0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j]])
+        expected_gate = np.array([[1, 0, 0, 0],
+                                  [0, 1, 0, 0],
+                                  [0, 0, 1, 0],
+                                  [0, 0, 0, -1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cy_three_qubits_qiskit_qubit_order(self,):
-        circ = TestCircuit(3)
+    def test_cz_three_qubits_qiskit_qubit_order(self,):
+        circ = StateVectorCircuit(3)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y, control_qubit=[0], target_qubit=[2], control_value=[1]
+            _Z, control_qubit=[0], target_qubit=[2], control_value=[1]
         )
 
         # this is qiskit's output
         expected_gate = np.array([
             [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j, 0.+0.j, 0.+0.j],
+            [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
             [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.-1.j],
+            [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
             [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-            [0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, -1.+0.j, 0.+0.j, 0.+0.j],
             [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
-            [0.+0.j, 0.+0.j, 0.+0.j, 0.+1.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])
+            [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, -1.+0.j]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cy_control_value_is_zero(self,):
-        circ = TestCircuit(2)
+    def test_cz_control_value_is_zero(self,):
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y, control_qubit=[0], target_qubit=[1], control_value=[0]
+            _Z, control_qubit=[0], target_qubit=[1], control_value=[0]
         )
 
-        expected_gate = np.array([[0, -1j, 0, 0],
-                                  [1j, 0, 0, 0],
+        expected_gate = np.array([[1, 0, 0, 0],
+                                  [0, -1, 0, 0],
                                   [0, 0, 1, 0],
                                   [0, 0, 0, 1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cy_multiple_controls(self,):
-        circ = TestCircuit(3)
+    def test_cz_multiple_controls(self,):
+        circ = StateVectorCircuit(3)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y,
+            _Z,
             control_qubit=[0, 1], target_qubit=[2], control_value=[1, 1])
 
         expected_gate = np.array([[1, 0, 0, 0, 0, 0, 0, 0],
@@ -113,25 +110,25 @@ class TestTestCircuitCYGate(unittest.TestCase):
                                   [0, 0, 0, 1, 0, 0, 0, 0],
                                   [0, 0, 0, 0, 1, 0, 0, 0],
                                   [0, 0, 0, 0, 0, 1, 0, 0],
-                                  [0, 0, 0, 0, 0, 0, 0, -1j],
-                                  [0, 0, 0, 0, 0, 0, 1j, 0]])
+                                  [0, 0, 0, 0, 0, 0, 1, 0],
+                                  [0, 0, 0, 0, 0, 0, 0, -1]])
 
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test_cy_multiple_targets(self,):
+    def test_cz_multiple_targets(self,):
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y, control_qubit=[0], target_qubit=[1, 2], control_value=[1]
+            _Z, control_qubit=[0], target_qubit=[1, 2], control_value=[1]
         )
 
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         gate_1_0 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y, control_qubit=[0], target_qubit=[1], control_value=[1]
+            _Z, control_qubit=[0], target_qubit=[1], control_value=[1]
         )
         gate_1_1 = circ._create_all_qubit_gate_from_original_qubit_gate(
-            _Y, control_qubit=[0], target_qubit=[2], control_value=[1]
+            _Z, control_qubit=[0], target_qubit=[2], control_value=[1]
         )
 
         self.assertIsNone(

--- a/test/simulator/state_vector_circuit/test_get_whole_gates.py
+++ b/test/simulator/state_vector_circuit/test_get_whole_gates.py
@@ -2,15 +2,16 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
+from quantestpy import StateVectorCircuit
 
 
-class TestTestCircuitGetWholeGates(unittest.TestCase):
+class TestStateVectorCircuitGetWholeGates(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_get_whole_gates
+    $ python -m \
+        unittest test.simulator.state_vector_circuit.test_get_whole_gates
     ............................
     ----------------------------------------------------------------------
     Ran 28 tests in 0.012s
@@ -20,7 +21,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
     """
 
     def test_get_whole_gates_id(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "id", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -36,7 +37,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_x(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "x", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -52,7 +53,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_y(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "y", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -68,7 +69,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_z(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "z", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -84,7 +85,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_h(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "h", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -100,7 +101,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_s(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "s", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -115,7 +116,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_sdg(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "sdg", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -130,7 +131,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_t(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "t", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -145,7 +146,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_tdg(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "tdg", "target_qubit": [1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -160,7 +161,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_rx(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         theta = np.pi/4
         circ.add_gate(
             {"name": "rx", "target_qubit": [1], "control_qubit": [],
@@ -177,7 +178,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_ry(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         theta = np.pi/4
         circ.add_gate(
             {"name": "ry", "target_qubit": [1], "control_qubit": [],
@@ -193,7 +194,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_rz(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/4
         circ.add_gate(
             {"name": "rz", "target_qubit": [1], "control_qubit": [],
@@ -209,7 +210,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_p(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/4
         circ.add_gate(
             {"name": "p", "target_qubit": [1], "control_qubit": [],
@@ -225,7 +226,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_u(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         theta = np.pi/16
         phi = np.pi/8
         lambda_ = np.pi/4
@@ -249,7 +250,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_cx(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "x", "target_qubit": [1], "control_qubit": [0],
              "control_value": [1], "parameter": []})
@@ -265,7 +266,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_cy(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "y", "target_qubit": [1], "control_qubit": [0],
              "control_value": [1], "parameter": []})
@@ -281,7 +282,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_cz(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "z", "target_qubit": [1], "control_qubit": [0],
              "control_value": [1], "parameter": []})
@@ -297,7 +298,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-07))
 
     def test_get_whole_gates_ch(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "h", "target_qubit": [1], "control_qubit": [0],
              "control_value": [1], "parameter": []})
@@ -313,7 +314,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-07))
 
     def test_get_whole_gates_crx(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         theta = np.pi/4
         circ.add_gate(
             {"name": "rx", "target_qubit": [1], "control_qubit": [0],
@@ -330,7 +331,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-07))
 
     def test_get_whole_gates_cry(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         theta = np.pi/4
         circ.add_gate(
             {"name": "ry", "target_qubit": [1], "control_qubit": [0],
@@ -346,7 +347,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-07))
 
     def test_get_whole_gates_crz(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/4
         circ.add_gate(
             {"name": "rz", "target_qubit": [1], "control_qubit": [0],
@@ -362,7 +363,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_cp(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         lambda_ = np.pi/4
         circ.add_gate(
             {"name": "p", "target_qubit": [1], "control_qubit": [0],
@@ -378,7 +379,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_cu(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         theta = np.pi/16
         phi = np.pi/8
         lambda_ = np.pi/4
@@ -407,7 +408,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
         ]
 
         for target_qubit, parameter in test_patterns:
-            circ = TestCircuit(3)
+            circ = StateVectorCircuit(3)
             circ.add_gate(
                 {"name": "scalar",
                  "target_qubit": [target_qubit],
@@ -439,7 +440,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
 
         for num_qubit, target_qubit, parameter in test_patterns:
 
-            circ = TestCircuit(num_qubit)
+            circ = StateVectorCircuit(num_qubit)
             circ.add_gate(
                 {"name": "scalar",
                     "target_qubit": target_qubit,
@@ -463,7 +464,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
                 np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_swap(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "swap", "target_qubit": [0, 1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -477,7 +478,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_cswap(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         circ.add_gate(
             {"name": "swap", "target_qubit": [1, 2], "control_qubit": [0],
              "control_value": [1], "parameter": []})
@@ -494,7 +495,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_iswap(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate(
             {"name": "iswap", "target_qubit": [0, 1], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -508,7 +509,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
                                        atol=1e-16))
 
     def test_get_whole_gates_ccswap(self,):
-        circ = TestCircuit(4)
+        circ = StateVectorCircuit(4)
         circ.add_gate(
             {"name": "swap", "target_qubit": [2, 3], "control_qubit": [0, 1],
              "control_value": [1, 1], "parameter": []})
@@ -535,7 +536,7 @@ class TestTestCircuitGetWholeGates(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_get_whole_gates_ciswap(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         circ.add_gate(
             {"name": "iswap", "target_qubit": [1, 2], "control_qubit": [0],
              "control_value": [1], "parameter": []})

--- a/test/simulator/state_vector_circuit/test_single_qubit_gate.py
+++ b/test/simulator/state_vector_circuit/test_single_qubit_gate.py
@@ -2,15 +2,17 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit, test_circuit
+from quantestpy import StateVectorCircuit
+from quantestpy.simulator import state_vector_circuit
 
 
-class TestTestCircuitSingleQubitGate(unittest.TestCase):
+class TestStateVectorCircuitSingleQubitGate(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit_single_qubit_gate
+    $ python -m unittest \
+        test.simulator.state_vector_circuit.test_single_qubit_gate
 
     ........
     ----------------------------------------------------------------------
@@ -21,8 +23,8 @@ class TestTestCircuitSingleQubitGate(unittest.TestCase):
     """
 
     def test_h_to_0_in_qubit_2(self,):
-        h = test_circuit._H
-        circ = TestCircuit(2)
+        h = state_vector_circuit._H
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             gate=h, control_qubit=[], target_qubit=[0], control_value=[]
         )
@@ -36,8 +38,8 @@ class TestTestCircuitSingleQubitGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_h_to_1_in_qubit_2(self,):
-        h = test_circuit._H
-        circ = TestCircuit(2)
+        h = state_vector_circuit._H
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             gate=h, control_qubit=[], target_qubit=[1], control_value=[]
         )
@@ -51,8 +53,8 @@ class TestTestCircuitSingleQubitGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_x_to_0_and_1_in_qubit_2(self,):
-        x = test_circuit._X
-        circ = TestCircuit(2)
+        x = state_vector_circuit._X
+        circ = StateVectorCircuit(2)
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             gate=x, control_qubit=[], target_qubit=[0, 1], control_value=[]
         )
@@ -66,8 +68,8 @@ class TestTestCircuitSingleQubitGate(unittest.TestCase):
             np.testing.assert_allclose(actual_gate, expected_gate))
 
     def test_h_to_0_and_1_in_qubit_3_qiskit_convention(self,):
-        h = test_circuit._H
-        circ = TestCircuit(3)
+        h = state_vector_circuit._H
+        circ = StateVectorCircuit(3)
         circ._from_right_to_left_for_qubit_ids = True
         actual_gate = circ._create_all_qubit_gate_from_original_qubit_gate(
             gate=h, control_qubit=[], target_qubit=[0, 1], control_value=[]

--- a/test/simulator/state_vector_circuit/test_state_vector_circuit.py
+++ b/test/simulator/state_vector_circuit/test_state_vector_circuit.py
@@ -2,15 +2,16 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit
+from quantestpy import StateVectorCircuit
 
 
-class TestTestCircuit(unittest.TestCase):
+class TestStateVectorCircuit(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.test_test_circuit
+    $ python -m \
+        unittest test.simulator.state_vector_circuit.test_state_vector_circuit
     ......
     ----------------------------------------------------------------------
     Ran 6 tests in 0.006s
@@ -20,7 +21,7 @@ class TestTestCircuit(unittest.TestCase):
     """
 
     def test__get_state_vector_1(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         actual_vec = circ._get_state_vector()
 
         expected_vec = np.array([1, 0, 0, 0])
@@ -29,7 +30,7 @@ class TestTestCircuit(unittest.TestCase):
             np.testing.assert_allclose(actual_vec, expected_vec))
 
     def test__get_state_vector_2(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate({"name": "h", "target_qubit": [0], "control_qubit": [],
                        "control_value": [], "parameter": []})
         circ.add_gate(
@@ -43,7 +44,7 @@ class TestTestCircuit(unittest.TestCase):
             np.testing.assert_allclose(actual_vec, expected_vec))
 
     def test__get_state_vector_3(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         circ.add_gate({"name": "x", "target_qubit": [0], "control_qubit": [],
                        "control_value": [], "parameter": []})
         circ.add_gate({"name": "x", "target_qubit": [1], "control_qubit": [],
@@ -59,7 +60,7 @@ class TestTestCircuit(unittest.TestCase):
             np.testing.assert_allclose(actual_vec, expected_vec))
 
     def test__get_state_vector_4(self,):
-        circ = TestCircuit(3)
+        circ = StateVectorCircuit(3)
         circ.add_gate({"name": "x", "target_qubit": [0], "control_qubit": [],
                        "control_value": [], "parameter": []})
         circ.add_gate(
@@ -75,7 +76,7 @@ class TestTestCircuit(unittest.TestCase):
             np.testing.assert_allclose(actual_vec, expected_vec))
 
     def test_set_initial_state_vector_1(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         init_vec = np.array([1, 1j, -1, -1]) / 2.
         circ.set_initial_state_vector(init_vec)
         actual_vec = circ._get_state_vector()
@@ -86,7 +87,7 @@ class TestTestCircuit(unittest.TestCase):
             np.testing.assert_allclose(actual_vec, expected_vec))
 
     def test_set_initial_state_vector_2(self,):
-        circ = TestCircuit(2)
+        circ = StateVectorCircuit(2)
         init_vec = np.array([1, 0, 1, 0]) / np.sqrt(2.)
         circ.set_initial_state_vector(init_vec)
         circ.add_gate(

--- a/test/test_circuit_assert_ancilla_is_zero.py
+++ b/test/test_circuit_assert_ancilla_is_zero.py
@@ -19,64 +19,64 @@ class TestCircuitAssertAncillaIsZero(unittest.TestCase):
     """
 
     def test_regular_1(self,):
-        test_circuit = QuantestPyCircuit(4)
+        qc = QuantestPyCircuit(4)
         # V
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [0], "target_qubit": [1],
              "control_value": [1], "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [1], "target_qubit": [2],
              "control_value": [1], "parameter": []}
         )
 
         # uncomputation
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [1], "target_qubit": [3],
              "control_value": [1], "parameter": []}
         )
 
         # V^{-1}
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [1], "target_qubit": [2],
              "control_value": [1], "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [0], "target_qubit": [1],
              "control_value": [1], "parameter": []}
         )
 
         self.assertIsNone(
             circuit.assert_ancilla_is_zero(
-                circuit=test_circuit,
+                circuit=qc,
                 ancilla_qubits=[1, 2]
             )
         )
 
     def test_irregular_1(self,):
-        test_circuit = QuantestPyCircuit(4)
+        qc = QuantestPyCircuit(4)
         # V
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [0], "target_qubit": [1],
              "control_value": [1], "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [1], "target_qubit": [2],
              "control_value": [1], "parameter": []}
         )
 
         # uncomputation
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [1], "target_qubit": [3],
              "control_value": [1], "parameter": []}
         )
 
         # V^{-1}: Wrong order!!
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [0], "target_qubit": [1],
              "control_value": [1], "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "control_qubit": [1], "target_qubit": [2],
              "control_value": [1], "parameter": []}
         )
@@ -84,7 +84,7 @@ class TestCircuitAssertAncillaIsZero(unittest.TestCase):
         try:
             self.assertIsNotNone(
                 circuit.assert_ancilla_is_zero(
-                    circuit=test_circuit,
+                    circuit=qc,
                     ancilla_qubits=[1, 2]
                 )
             )

--- a/test/test_circuit_assert_ancilla_is_zero.py
+++ b/test/test_circuit_assert_ancilla_is_zero.py
@@ -1,7 +1,7 @@
 import traceback
 import unittest
 
-from quantestpy import TestCircuit, circuit
+from quantestpy import QuantestPyCircuit, circuit
 from quantestpy.exceptions import QuantestPyAssertionError
 
 
@@ -19,7 +19,7 @@ class TestCircuitAssertAncillaIsZero(unittest.TestCase):
     """
 
     def test_regular_1(self,):
-        test_circuit = TestCircuit(4)
+        test_circuit = QuantestPyCircuit(4)
         # V
         test_circuit.add_gate(
             {"name": "x", "control_qubit": [0], "target_qubit": [1],
@@ -54,7 +54,7 @@ class TestCircuitAssertAncillaIsZero(unittest.TestCase):
         )
 
     def test_irregular_1(self,):
-        test_circuit = TestCircuit(4)
+        test_circuit = QuantestPyCircuit(4)
         # V
         test_circuit.add_gate(
             {"name": "x", "control_qubit": [0], "target_qubit": [1],

--- a/test/test_circuit_assert_equal_to_operator.py
+++ b/test/test_circuit_assert_equal_to_operator.py
@@ -22,16 +22,16 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
 
     def setUp(self) -> None:
         """Prepare the Bell state"""
-        self.test_circ = QuantestPyCircuit(2)
-        self.test_circ.add_gate(
+        self.qc = QuantestPyCircuit(2)
+        self.qc.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []})
-        self.test_circ.add_gate(
+        self.qc.add_gate(
             {"name": "x", "control_qubit": [0],  "target_qubit": [1],
              "control_value": [1], "parameter": []})
 
     def tearDown(self) -> None:
-        del self.test_circ
+        del self.qc
 
     def test_assert_equal_to_operator_1(self,):
 
@@ -45,7 +45,7 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
         self.assertIsNone(
             circuit.assert_equal_to_operator(
                 operator_=expected_operator,
-                circuit=self.test_circ
+                circuit=self.qc
             )
         )
 
@@ -61,7 +61,7 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
         with self.assertRaises(QuantestPyAssertionError):
             circuit.assert_equal_to_operator(
                 operator_=expected_operator,
-                circuit=self.test_circ,
+                circuit=self.qc,
                 from_right_to_left_for_qubit_ids=True  # Qiskit convention
             )
 
@@ -77,7 +77,7 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
         self.assertIsNone(
             circuit.assert_equal_to_operator(
                 operator_=expected_operator,
-                circuit=self.test_circ,
+                circuit=self.qc,
                 from_right_to_left_for_qubit_ids=True  # Qiskit convention
             )
         )
@@ -94,5 +94,5 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
         with self.assertRaises(QuantestPyAssertionError):
             circuit.assert_equal_to_operator(
                 operator_=expected_operator,
-                circuit=self.test_circ
+                circuit=self.qc
             )

--- a/test/test_circuit_assert_equal_to_operator.py
+++ b/test/test_circuit_assert_equal_to_operator.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from quantestpy import TestCircuit, circuit
+from quantestpy import QuantestPyCircuit, circuit
 from quantestpy.exceptions import QuantestPyAssertionError
 
 
@@ -22,7 +22,7 @@ class TestCircuitAssertEqualToOperator(unittest.TestCase):
 
     def setUp(self) -> None:
         """Prepare the Bell state"""
-        self.test_circ = TestCircuit(2)
+        self.test_circ = QuantestPyCircuit(2)
         self.test_circ.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []})

--- a/test/test_circuit_assert_is_zero.py
+++ b/test/test_circuit_assert_is_zero.py
@@ -1,6 +1,6 @@
 import unittest
 
-from quantestpy import TestCircuit, circuit
+from quantestpy import QuantestPyCircuit, circuit
 from quantestpy.exceptions import QuantestPyAssertionError
 
 
@@ -18,7 +18,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
     """
 
     def test_regular_1(self,):
-        test_circuit = TestCircuit(3)
+        test_circuit = QuantestPyCircuit(3)
         test_circuit.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []}
@@ -36,7 +36,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
         )
 
     def test_regular_2(self,):
-        test_circuit = TestCircuit(4)
+        test_circuit = QuantestPyCircuit(4)
         test_circuit.add_gate(
             {"name": "h", "target_qubit": [3], "control_qubit": [],
              "control_value": [], "parameter": []}
@@ -54,7 +54,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
         )
 
     def test_irregular_1(self,):
-        test_circuit = TestCircuit(2)
+        test_circuit = QuantestPyCircuit(2)
         test_circuit.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []}
@@ -72,7 +72,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
     def test_large_a_tol_raise_no_error(self,):
         """Assertion error does not raise for Bell state when a_tol is large
         """
-        test_circuit = TestCircuit(2)
+        test_circuit = QuantestPyCircuit(2)
         test_circuit.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []}

--- a/test/test_circuit_assert_is_zero.py
+++ b/test/test_circuit_assert_is_zero.py
@@ -18,66 +18,66 @@ class TestCircuitAssertIsZero(unittest.TestCase):
     """
 
     def test_regular_1(self,):
-        test_circuit = QuantestPyCircuit(3)
-        test_circuit.add_gate(
+        qc = QuantestPyCircuit(3)
+        qc.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "target_qubit": [2], "control_qubit": [],
              "control_value": [], "parameter": []}
         )
 
         self.assertIsNone(
             circuit.assert_is_zero(
-                circuit=test_circuit,
+                circuit=qc,
                 qubits=[1]
             )
         )
 
     def test_regular_2(self,):
-        test_circuit = QuantestPyCircuit(4)
-        test_circuit.add_gate(
+        qc = QuantestPyCircuit(4)
+        qc.add_gate(
             {"name": "h", "target_qubit": [3], "control_qubit": [],
              "control_value": [], "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [3],
              "control_value": [1], "parameter": []}
         )
 
         self.assertIsNone(
             circuit.assert_is_zero(
-                circuit=test_circuit,
+                circuit=qc,
                 qubits=[1, 2]
             )
         )
 
     def test_irregular_1(self,):
-        test_circuit = QuantestPyCircuit(2)
-        test_circuit.add_gate(
+        qc = QuantestPyCircuit(2)
+        qc.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "target_qubit": [1], "control_qubit": [0],
              "control_value": [1], "parameter": []}
         )
 
         with self.assertRaises(QuantestPyAssertionError):
             circuit.assert_is_zero(
-                circuit=test_circuit
+                circuit=qc
             )
 
     def test_large_a_tol_raise_no_error(self,):
         """Assertion error does not raise for Bell state when a_tol is large
         """
-        test_circuit = QuantestPyCircuit(2)
-        test_circuit.add_gate(
+        qc = QuantestPyCircuit(2)
+        qc.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []}
         )
-        test_circuit.add_gate(
+        qc.add_gate(
             {"name": "x", "target_qubit": [1], "control_qubit": [0],
              "control_value": [1], "parameter": []}
         )
@@ -85,7 +85,7 @@ class TestCircuitAssertIsZero(unittest.TestCase):
         # no error
         self.assertIsNone(
             circuit.assert_is_zero(
-                circuit=test_circuit,
+                circuit=qc,
                 atol=0.71
             )
         )
@@ -93,6 +93,6 @@ class TestCircuitAssertIsZero(unittest.TestCase):
         # error
         with self.assertRaises(QuantestPyAssertionError):
             circuit.assert_is_zero(
-                circuit=test_circuit,
+                circuit=qc,
                 atol=0.7
             )

--- a/test/with_qiskit/test_circuit_assert_equal.py
+++ b/test/with_qiskit/test_circuit_assert_equal.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 from qiskit import QuantumCircuit
 
-from quantestpy import TestCircuit, circuit
+from quantestpy import QuantestPyCircuit, circuit
 from quantestpy.exceptions import QuantestPyAssertionError, QuantestPyError
 
 
@@ -24,7 +24,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
     def test_msg_from_wrong_input_type_for_circuit_a(self,):
 
         circuit_a = np.array([[0, 1], [1, 0]])  # wrong
-        circuit_b = TestCircuit(2)  # correct
+        circuit_b = QuantestPyCircuit(2)  # correct
 
         try:
             self.assertIsNotNone(
@@ -39,7 +39,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
             expected_error_msg = \
                 "quantestpy.exceptions.QuantestPyError: " \
                 + "Input circuit must be one of the following: " \
-                + "qasm, qiskit.QuantumCircuit and TestCircuit.\n"
+                + "qasm, qiskit.QuantumCircuit and QuantestPyCircuit.\n"
 
             actual_error_msg = \
                 traceback.format_exception_only(type(e), e)[0]
@@ -64,7 +64,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
             expected_error_msg = \
                 "quantestpy.exceptions.QuantestPyError: " \
                 + "Input circuit must be one of the following: " \
-                + "qasm, qiskit.QuantumCircuit and TestCircuit.\n"
+                + "qasm, qiskit.QuantumCircuit and QuantestPyCircuit.\n"
 
             actual_error_msg = \
                 traceback.format_exception_only(type(e), e)[0]
@@ -73,7 +73,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_exact_equal(self,):
         """Check CNOT basis transformation; see Nielsen-Chuang p.179"""
-        test_circuit_a = TestCircuit(2)
+        test_circuit_a = QuantestPyCircuit(2)
         test_circuit_a.add_gate(
             {"name": "h", "target_qubit": [0, 1], "control_qubit": [],
                 "control_value": [], "parameter": []}
@@ -87,7 +87,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
                 "control_value": [], "parameter": []}
         )
 
-        test_circuit_b = TestCircuit(2)
+        test_circuit_b = QuantestPyCircuit(2)
         test_circuit_b.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [1],
                 "control_value": [1], "parameter": []}
@@ -102,8 +102,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_msg_from_wrong_type_for_atol(self,):
 
-        test_circuit_a = TestCircuit(2)
-        test_circuit_b = TestCircuit(2)
+        test_circuit_a = QuantestPyCircuit(2)
+        test_circuit_b = QuantestPyCircuit(2)
 
         test_patterns = [
             1,
@@ -135,7 +135,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_matrix_norms(self,):
 
-        test_circuit_a = TestCircuit(2)
+        test_circuit_a = QuantestPyCircuit(2)
         test_circuit_a.add_gate(
             {"name": "x", "target_qubit": [0, 1], "control_qubit": [],
                 "control_value": [], "parameter": []}
@@ -145,7 +145,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
                 "control_value": [], "parameter": []}
         )
 
-        test_circuit_b = TestCircuit(2)
+        test_circuit_b = QuantestPyCircuit(2)
         test_circuit_b.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [1],
                 "control_value": [1], "parameter": []}
@@ -195,13 +195,13 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_operator_norm_2(self,):
 
-        test_circuit_a = TestCircuit(1)
+        test_circuit_a = QuantestPyCircuit(1)
         test_circuit_a.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
 
-        test_circuit_b = TestCircuit(1)
+        test_circuit_b = QuantestPyCircuit(1)
         test_circuit_b.add_gate(
             {"name": "s", "target_qubit": [0], "control_qubit": [],
                 "control_value": [], "parameter": []}
@@ -232,7 +232,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_matrix_norms_with_rtol(self,):
 
-        test_circuit_a = TestCircuit(2)
+        test_circuit_a = QuantestPyCircuit(2)
         test_circuit_a.add_gate(
             {"name": "x", "target_qubit": [0, 1], "control_qubit": [],
                 "control_value": [], "parameter": []}
@@ -242,7 +242,7 @@ class TestCircuitAssertEqual(unittest.TestCase):
                 "control_value": [], "parameter": []}
         )
 
-        test_circuit_b = TestCircuit(2)
+        test_circuit_b = QuantestPyCircuit(2)
         test_circuit_b.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [1],
                 "control_value": [1], "parameter": []}

--- a/test/with_qiskit/test_circuit_assert_equal.py
+++ b/test/with_qiskit/test_circuit_assert_equal.py
@@ -73,37 +73,37 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_exact_equal(self,):
         """Check CNOT basis transformation; see Nielsen-Chuang p.179"""
-        test_circuit_a = QuantestPyCircuit(2)
-        test_circuit_a.add_gate(
+        qc_a = QuantestPyCircuit(2)
+        qc_a.add_gate(
             {"name": "h", "target_qubit": [0, 1], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
-        test_circuit_a.add_gate(
+        qc_a.add_gate(
             {"name": "x", "target_qubit": [1], "control_qubit": [0],
                 "control_value": [1], "parameter": []}
         )
-        test_circuit_a.add_gate(
+        qc_a.add_gate(
             {"name": "h", "target_qubit": [0, 1], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
 
-        test_circuit_b = QuantestPyCircuit(2)
-        test_circuit_b.add_gate(
+        qc_b = QuantestPyCircuit(2)
+        qc_b.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [1],
                 "control_value": [1], "parameter": []}
         )
 
         self.assertIsNone(
             circuit.assert_equal(
-                circuit_a=test_circuit_a,
-                circuit_b=test_circuit_b
+                circuit_a=qc_a,
+                circuit_b=qc_b
             )
         )
 
     def test_msg_from_wrong_type_for_atol(self,):
 
-        test_circuit_a = QuantestPyCircuit(2)
-        test_circuit_b = QuantestPyCircuit(2)
+        qc_a = QuantestPyCircuit(2)
+        qc_b = QuantestPyCircuit(2)
 
         test_patterns = [
             1,
@@ -116,8 +116,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
             try:
                 self.assertIsNotNone(
                     circuit.assert_equal(
-                        circuit_a=test_circuit_a,
-                        circuit_b=test_circuit_b,
+                        circuit_a=qc_a,
+                        circuit_b=qc_b,
                         atol=tolerance
                     )
                 )
@@ -135,18 +135,18 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_matrix_norms(self,):
 
-        test_circuit_a = QuantestPyCircuit(2)
-        test_circuit_a.add_gate(
+        qc_a = QuantestPyCircuit(2)
+        qc_a.add_gate(
             {"name": "x", "target_qubit": [0, 1], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
-        test_circuit_a.add_gate(
+        qc_a.add_gate(
             {"name": "s", "target_qubit": [1], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
 
-        test_circuit_b = QuantestPyCircuit(2)
-        test_circuit_b.add_gate(
+        qc_b = QuantestPyCircuit(2)
+        qc_b.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [1],
                 "control_value": [1], "parameter": []}
         )
@@ -171,8 +171,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
             try:
                 self.assertIsNotNone(
                     circuit.assert_equal(
-                        circuit_a=test_circuit_a,
-                        circuit_b=test_circuit_b,
+                        circuit_a=qc_a,
+                        circuit_b=qc_b,
                         matrix_norm_type=pattern["matrix_norm_type"],
                         atol=pattern["atol"]
                     )
@@ -195,14 +195,14 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_operator_norm_2(self,):
 
-        test_circuit_a = QuantestPyCircuit(1)
-        test_circuit_a.add_gate(
+        qc_a = QuantestPyCircuit(1)
+        qc_a.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
 
-        test_circuit_b = QuantestPyCircuit(1)
-        test_circuit_b.add_gate(
+        qc_b = QuantestPyCircuit(1)
+        qc_b.add_gate(
             {"name": "s", "target_qubit": [0], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
@@ -210,8 +210,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
         try:
             self.assertIsNotNone(
                 circuit.assert_equal(
-                    circuit_a=test_circuit_a,
-                    circuit_b=test_circuit_b,
+                    circuit_a=qc_a,
+                    circuit_b=qc_b,
                     matrix_norm_type="operator_norm_2",
                     atol=1.5
                 )
@@ -232,18 +232,18 @@ class TestCircuitAssertEqual(unittest.TestCase):
 
     def test_matrix_norms_with_rtol(self,):
 
-        test_circuit_a = QuantestPyCircuit(2)
-        test_circuit_a.add_gate(
+        qc_a = QuantestPyCircuit(2)
+        qc_a.add_gate(
             {"name": "x", "target_qubit": [0, 1], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
-        test_circuit_a.add_gate(
+        qc_a.add_gate(
             {"name": "s", "target_qubit": [1], "control_qubit": [],
                 "control_value": [], "parameter": []}
         )
 
-        test_circuit_b = QuantestPyCircuit(2)
-        test_circuit_b.add_gate(
+        qc_b = QuantestPyCircuit(2)
+        qc_b.add_gate(
             {"name": "x", "target_qubit": [0], "control_qubit": [1],
                 "control_value": [1], "parameter": []}
         )
@@ -272,8 +272,8 @@ class TestCircuitAssertEqual(unittest.TestCase):
             try:
                 self.assertIsNotNone(
                     circuit.assert_equal(
-                        circuit_a=test_circuit_a,
-                        circuit_b=test_circuit_b,
+                        circuit_a=qc_a,
+                        circuit_b=qc_b,
                         matrix_norm_type=pattern["matrix_norm_type"],
                         atol=0.,
                         rtol=pattern["rtol"]

--- a/test/with_qiskit/test_converter.py
+++ b/test/with_qiskit/test_converter.py
@@ -4,8 +4,8 @@ import numpy as np
 from qiskit import QuantumCircuit
 
 from quantestpy import QuantestPyCircuit
-from quantestpy.converter.qasm_and_qiskit import (
-    _cvt_openqasm_to_quantestpy_circuit, _cvt_qiskit_to_quantestpy_circuit)
+from quantestpy.converter.sdk.qasm import _cvt_openqasm_to_quantestpy_circuit
+from quantestpy.converter.sdk.qiskit import _cvt_qiskit_to_quantestpy_circuit
 from quantestpy.simulator.state_vector_circuit import \
     cvt_quantestpy_circuit_to_state_vector_circuit
 

--- a/test/with_qiskit/test_converter.py
+++ b/test/with_qiskit/test_converter.py
@@ -23,7 +23,7 @@ class TestConverter(unittest.TestCase):
     OK
     """
 
-    def test__cvt_qiskit_to_test_circuit(self,):
+    def test__cvt_qiskit_to_quantestpy_circuit(self,):
         qc = QuantumCircuit(2, 2)
         qc.h(0)
         qc.cx(0, 1)
@@ -44,7 +44,7 @@ class TestConverter(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test__cvt_openqasm_to_test_circuit(self,):
+    def test__cvt_openqasm_to_quantestpy_circuit(self,):
         qc = QuantumCircuit(2, 2)
         qc.h(0)
         qc.cx(0, 1)
@@ -66,7 +66,7 @@ class TestConverter(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
-    def test__cvt_qiskit_to_test_circuit_control_gates_1(self,):
+    def test__cvt_qiskit_to_quantestpy_circuit_control_gates_1(self,):
         qc = QuantumCircuit(3)
         qc.cx(0, 1)
         qc.cy(0, 1)
@@ -95,7 +95,7 @@ class TestConverter(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-15))
 
-    def test__cvt_qiskit_to_test_circuit_control_gates_2(self,):
+    def test__cvt_qiskit_to_quantestpy_circuit_control_gates_2(self,):
         theta = np.pi/4
 
         qc = QuantumCircuit(3)
@@ -122,7 +122,7 @@ class TestConverter(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-15))
 
-    def test__cvt_qiskit_to_test_circuit_control_gates_3(self,):
+    def test__cvt_qiskit_to_quantestpy_circuit_control_gates_3(self,):
         theta = np.pi/4
         phi = np.pi/8
         lambda_ = np.pi/16
@@ -153,7 +153,7 @@ class TestConverter(unittest.TestCase):
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-15))
 
-    def test__cvt_qiskit_to_test_circuit_global_phase(self,):
+    def test__cvt_qiskit_to_quantestpy_circuit_global_phase(self,):
 
         qc = QuantumCircuit(3, global_phase=np.pi/7.)
         qc.h(0)

--- a/test/with_qiskit/test_converter.py
+++ b/test/with_qiskit/test_converter.py
@@ -4,9 +4,8 @@ import numpy as np
 from qiskit import QuantumCircuit
 
 from quantestpy import QuantestPyCircuit
-from quantestpy.converter.qasm_and_qiskit import \
-    (_cvt_openqasm_to_quantestpy_circuit,
-     _cvt_qiskit_to_quantestpy_circuit)
+from quantestpy.converter.qasm_and_qiskit import (
+    _cvt_openqasm_to_quantestpy_circuit, _cvt_qiskit_to_quantestpy_circuit)
 from quantestpy.simulator.state_vector_circuit import \
     cvt_quantestpy_circuit_to_state_vector_circuit
 

--- a/test/with_qiskit/test_converter.py
+++ b/test/with_qiskit/test_converter.py
@@ -16,8 +16,7 @@ class TestConverter(unittest.TestCase):
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest \
-        test_with_external_module.with_qiskit.converter.qasm_and_qiskit.test_converter
+    $ python -m unittest test.with_qiskit.test_converter
     ......
     ----------------------------------------------------------------------
     Ran 6 tests in 0.060s

--- a/test/with_qiskit/test_converter_to_quantestpy_circuit.py
+++ b/test/with_qiskit/test_converter_to_quantestpy_circuit.py
@@ -1,0 +1,48 @@
+import unittest
+
+import numpy as np
+from qiskit import QuantumCircuit
+
+from quantestpy import QuantestPyCircuit
+from quantestpy.converter.converter_to_quantestpy_circuit import \
+    cvt_input_circuit_to_quantestpy_circuit
+from quantestpy.exceptions import QuantestPyError
+
+
+class TestConverterToQuantestPyCircuit(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.with_qiskit.test_converter_to_quantestpy_circuit
+    ....
+    ----------------------------------------------------------------------
+    Ran 4 tests in 0.101s
+
+    OK
+    """
+
+    def test_cvt_quantestpy_circuit(self,):
+        input_circuit = QuantestPyCircuit(10)
+        qc = cvt_input_circuit_to_quantestpy_circuit(input_circuit)
+        self.assertIsInstance(qc, QuantestPyCircuit)
+
+    def test_cvt_qasm(self,):
+        input_circuit = QuantumCircuit(3).qasm()
+        qc = cvt_input_circuit_to_quantestpy_circuit(input_circuit)
+        self.assertIsInstance(qc, QuantestPyCircuit)
+
+    def test_cvt_qiskit(self,):
+        input_circuit = QuantumCircuit(3)
+        qc = cvt_input_circuit_to_quantestpy_circuit(input_circuit)
+        self.assertIsInstance(qc, QuantestPyCircuit)
+
+    def test_cvt_others(self,):
+        input_circuit = np.array([0, 1])
+        expected_error_msg = "Input circuit must be one of the following: " \
+            + "qasm, qiskit.QuantumCircuit and QuantestPyCircuit."
+
+        with self.assertRaises(QuantestPyError) as cm:
+            _ = cvt_input_circuit_to_quantestpy_circuit(input_circuit)
+
+        self.assertEqual(cm.exception.args[0], expected_error_msg)

--- a/test_with_external_module/with_qiskit/converter/qasm_and_qiskit/test_converter.py
+++ b/test_with_external_module/with_qiskit/converter/qasm_and_qiskit/test_converter.py
@@ -3,9 +3,12 @@ import unittest
 import numpy as np
 from qiskit import QuantumCircuit
 
-from quantestpy import TestCircuit
-from quantestpy.converter import (_cvt_openqasm_to_test_circuit,
-                                  _cvt_qiskit_to_test_circuit)
+from quantestpy import QuantestPyCircuit
+from quantestpy.converter.qasm_and_qiskit import \
+    (_cvt_openqasm_to_quantestpy_circuit,
+     _cvt_qiskit_to_quantestpy_circuit)
+from quantestpy.simulator.state_vector_circuit import \
+    cvt_quantestpy_circuit_to_state_vector_circuit
 
 
 class TestConverter(unittest.TestCase):
@@ -13,7 +16,8 @@ class TestConverter(unittest.TestCase):
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
-    $ python -m unittest test.with_qiskit.test_converter
+    $ python -m unittest \
+        test_with_external_module.with_qiskit.converter.qasm_and_qiskit.test_converter
     ......
     ----------------------------------------------------------------------
     Ran 6 tests in 0.060s
@@ -25,9 +29,9 @@ class TestConverter(unittest.TestCase):
         qc = QuantumCircuit(2, 2)
         qc.h(0)
         qc.cx(0, 1)
-        actual_circuit = _cvt_qiskit_to_test_circuit(qc)
+        actual_circuit = _cvt_qiskit_to_quantestpy_circuit(qc)
 
-        expected_circuit = TestCircuit(2)
+        expected_circuit = QuantestPyCircuit(2)
         expected_circuit.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -35,8 +39,10 @@ class TestConverter(unittest.TestCase):
                                    "control_qubit": [0], "control_value": [1],
                                    "parameter": []})
 
-        actual_gate = actual_circuit._get_whole_gates()
-        expected_gate = expected_circuit._get_whole_gates()
+        actual_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            actual_circuit)._get_whole_gates()
+        expected_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            expected_circuit)._get_whole_gates()
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
@@ -45,9 +51,9 @@ class TestConverter(unittest.TestCase):
         qc.h(0)
         qc.cx(0, 1)
         qasm = qc.qasm()
-        actual_circuit = _cvt_openqasm_to_test_circuit(qasm)
+        actual_circuit = _cvt_openqasm_to_quantestpy_circuit(qasm)
 
-        expected_circuit = TestCircuit(2)
+        expected_circuit = QuantestPyCircuit(2)
         expected_circuit.add_gate(
             {"name": "h", "target_qubit": [0], "control_qubit": [],
              "control_value": [], "parameter": []})
@@ -55,8 +61,10 @@ class TestConverter(unittest.TestCase):
                                    "control_qubit": [0], "control_value": [1],
                                    "parameter": []})
 
-        actual_gate = actual_circuit._get_whole_gates()
-        expected_gate = expected_circuit._get_whole_gates()
+        actual_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            actual_circuit)._get_whole_gates()
+        expected_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            expected_circuit)._get_whole_gates()
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate))
 
@@ -66,9 +74,9 @@ class TestConverter(unittest.TestCase):
         qc.cy(0, 1)
         qc.cz(0, 1)
         qc.ch(0, 1)
-        actual_circuit = _cvt_qiskit_to_test_circuit(qc)
+        actual_circuit = _cvt_qiskit_to_quantestpy_circuit(qc)
 
-        expected_circuit = TestCircuit(3)
+        expected_circuit = QuantestPyCircuit(3)
         expected_circuit.add_gate({"name": "x", "target_qubit": [1],
                                    "control_qubit": [0], "control_value": [1],
                                    "parameter": []})
@@ -82,8 +90,10 @@ class TestConverter(unittest.TestCase):
                                    "control_qubit": [0], "control_value": [1],
                                    "parameter": []})
 
-        actual_gate = actual_circuit._get_whole_gates()
-        expected_gate = expected_circuit._get_whole_gates()
+        actual_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            actual_circuit)._get_whole_gates()
+        expected_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            expected_circuit)._get_whole_gates()
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-15))
 
@@ -94,9 +104,9 @@ class TestConverter(unittest.TestCase):
         qc.crx(theta, 0, 1)
         qc.cry(theta, 0, 1)
         qc.crz(theta, 0, 1)
-        actual_circuit = _cvt_qiskit_to_test_circuit(qc)
+        actual_circuit = _cvt_qiskit_to_quantestpy_circuit(qc)
 
-        expected_circuit = TestCircuit(3)
+        expected_circuit = QuantestPyCircuit(3)
         expected_circuit.add_gate({"name": "rx", "target_qubit": [1],
                                    "control_qubit": [0], "control_value": [1],
                                    "parameter": [theta]})
@@ -107,8 +117,10 @@ class TestConverter(unittest.TestCase):
                                    "control_qubit": [0], "control_value": [1],
                                    "parameter": [theta]})
 
-        actual_gate = actual_circuit._get_whole_gates()
-        expected_gate = expected_circuit._get_whole_gates()
+        actual_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            actual_circuit)._get_whole_gates()
+        expected_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            expected_circuit)._get_whole_gates()
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-15))
 
@@ -122,9 +134,9 @@ class TestConverter(unittest.TestCase):
         qc.cp(theta, 0, 1)
         qc.cu(theta, phi, lambda_, gamma, 0, 1)
         qc.ccx(0, 1, 2)
-        actual_circuit = _cvt_qiskit_to_test_circuit(qc)
+        actual_circuit = _cvt_qiskit_to_quantestpy_circuit(qc)
 
-        expected_circuit = TestCircuit(3)
+        expected_circuit = QuantestPyCircuit(3)
         expected_circuit.add_gate({"name": "p", "target_qubit": [1],
                                    "control_qubit": [0], "control_value": [1],
                                    "parameter": [theta]})
@@ -136,8 +148,10 @@ class TestConverter(unittest.TestCase):
                                    "control_value": [1, 1],
                                    "parameter": []})
 
-        actual_gate = actual_circuit._get_whole_gates()
-        expected_gate = expected_circuit._get_whole_gates()
+        actual_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            actual_circuit)._get_whole_gates()
+        expected_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            expected_circuit)._get_whole_gates()
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-15))
 
@@ -146,9 +160,9 @@ class TestConverter(unittest.TestCase):
         qc = QuantumCircuit(3, global_phase=np.pi/7.)
         qc.h(0)
         qc.ccx(0, 1, 2)
-        actual_circuit = _cvt_qiskit_to_test_circuit(qc)
+        actual_circuit = _cvt_qiskit_to_quantestpy_circuit(qc)
 
-        expected_circuit = TestCircuit(3)
+        expected_circuit = QuantestPyCircuit(3)
         expected_circuit.add_gate({"name": "h",
                                    "target_qubit": [0],
                                    "control_qubit": [],
@@ -165,7 +179,9 @@ class TestConverter(unittest.TestCase):
                                    "control_value": [],
                                    "parameter": [np.pi/7.]})
 
-        actual_gate = actual_circuit._get_whole_gates()
-        expected_gate = expected_circuit._get_whole_gates()
+        actual_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            actual_circuit)._get_whole_gates()
+        expected_gate = cvt_quantestpy_circuit_to_state_vector_circuit(
+            expected_circuit)._get_whole_gates()
         self.assertIsNone(
             np.testing.assert_allclose(actual_gate, expected_gate, atol=1e-15))


### PR DESCRIPTION
In this PR, I rename `TestCircuit` class to `StateVectorCircuit`, and newly add `QuantestPyCircuit` class as the base class for `StateVectorCircuit` and `PauliCircuit` class.
 
It is intended that the assert methods accept an instance of  `QuantestPyCircuit` and internally convert it to either `StateVectorCircuit` or `PauliCircuit` as necessary. Therefore, the two converters `cvt_quantestpy_circuit_to_pauli_circuit()` and `cvt_quantestpy_circuit_to_state_vector_circuit()` are also implemented:
```py
In [1]: from quantestpy import QuantestPyCircuit
   ...: from quantestpy.simulator.pauli_circuit import cvt_quantestpy_circuit_to_pauli_circuit
   ...: from quantestpy.simulator.state_vector_circuit import cvt_quantestpy_circuit_to_state_vector_circuit
   ...: 
   ...: circ = QuantestPyCircuit(3)
   ...: circ.add_gate({"name": "x", "target_qubit": [0], "control_qubit": [],
   ...:                "control_value": [], "parameter": []})
   ...: circ.add_gate({"name": "x", "target_qubit": [2], "control_qubit": [0],
   ...:                "control_value": [1], "parameter": []})
   ...: circ.add_gate({"name": "y", "target_qubit": [0], "control_qubit": [],
   ...:                "control_value": [], "parameter": []})

In [2]: circ
Out[2]: <quantestpy.simulator.quantestpy_circuit.QuantestPyCircuit at 0x7f34647d65b0>

In [3]: pauli_circ = cvt_quantestpy_circuit_to_pauli_circuit(circ)

In [4]: pauli_circ
Out[4]: <quantestpy.simulator.pauli_circuit.PauliCircuit at 0x7f3464ae29a0>

In [5]: state_vec_circ = cvt_quantestpy_circuit_to_state_vector_circuit(circ)

In [6]: state_vec_circ
Out[6]: <quantestpy.simulator.state_vector_circuit.StateVectorCircuit at 0x7f34649d89d0>
```

Although there are 40 files changed, 30 of them are test files, in most of which the small changes like `TestCircuit` -> `QuantestPyCircuit` are done. Thank you in advance!
 