### PR TITLE
Add a new assert method testing unary iteration circuits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,4 @@ extend_skip_glob = ["*__init__.py"]
 skip = ["./test/assertion/assert_circuit_equivalent_to_output_qubit_state/test_draw_circuit.py",
 "./test/assertion/assert_circuit_equivalent_to_output_qubit_state/test_assert_internal.py",
 "./test/assertion/assert_circuit_equivalent_to_output_qubit_state/test_drawer.py",
-"./quantestpy/assertion/assert_unary_iteration.py"]
+"assert_unary_iteration.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,5 @@ per-file-ignores = "__init__.py:F401"
 extend_skip_glob = ["*__init__.py"]
 skip = ["./test/assertion/assert_circuit_equivalent_to_output_qubit_state/test_draw_circuit.py",
 "./test/assertion/assert_circuit_equivalent_to_output_qubit_state/test_assert_internal.py",
-"./test/assertion/assert_circuit_equivalent_to_output_qubit_state/test_drawer.py"]
+"./test/assertion/assert_circuit_equivalent_to_output_qubit_state/test_drawer.py",
+"./quantestpy/assertion/assert_unary_iteration.py"]

--- a/quantestpy/__init__.py
+++ b/quantestpy/__init__.py
@@ -6,6 +6,7 @@ from .assertion.get_ctrl_val import assert_get_ctrl_val
 from .assertion.get_tgt_val import assert_get_tgt_val
 from .assertion.assert_circuit_equivalent_to_output_qubit_state \
     import assert_circuit_equivalent_to_output_qubit_state
+from .assertion.assert_unary_iteration import assert_unary_iteration
 
 from .assertion.assert_circuit_equivalent_to_operator import \
     assert_circuit_equivalent_to_operator

--- a/quantestpy/assertion/assert_unary_iteration.py
+++ b/quantestpy/assertion/assert_unary_iteration.py
@@ -21,7 +21,7 @@ def _is_a_in_b(a: list, b: list) -> bool:
     return False
 
 
-def _assert_internal_replacing_gates_in_system_reg_with_x_gates(
+def _assert_equal_qubit_state_replacing_gates_in_sys_reg_with_x_gates(
         pauli_circuit_org: PauliCircuit,
         index_reg: list,
         system_reg: list,
@@ -79,6 +79,10 @@ def _draw_circuit(pauli_circuit_org: PauliCircuit,
                   err_msg: str,
                   val_err_reg: list,
                   replace_gate: bool = True) -> None:
+    # Check input
+    if len(system_reg) > 0 and len(ancilla_reg) > 0:
+        raise QuantestPyError("Unexpected error. Please report.")
+
     # define the circuit
     pc = copy.deepcopy(pauli_circuit_org)
     pc.set_qubit_value(index_reg, [int(i) for i in in_bitstring])
@@ -163,7 +167,7 @@ def assert_unary_iteration(
 
         # check actual == expect
         return_from_assert_equal = \
-            _assert_internal_replacing_gates_in_system_reg_with_x_gates(
+            _assert_equal_qubit_state_replacing_gates_in_sys_reg_with_x_gates(
                 pc_org,
                 index_reg,
                 system_reg,

--- a/quantestpy/assertion/assert_unary_iteration.py
+++ b/quantestpy/assertion/assert_unary_iteration.py
@@ -126,7 +126,6 @@ def assert_unary_iteration(
         system_reg: list,
         input_to_output: dict,
         ancilla_reg: list = [],
-        check_ancilla_is_uncomputed: bool = False,
         draw_circuit: bool = False):
     """
     e.g.
@@ -144,8 +143,6 @@ def assert_unary_iteration(
     pc_org._assert_is_correct_reg(ancilla_reg)
     if not isinstance(input_to_output, dict):
         raise QuantestPyError("input_to_output must be a dict.")
-    if not isinstance(check_ancilla_is_uncomputed, bool):
-        raise QuantestPyError("check_ancilla_is_uncomputed must be bool type.")
     if not isinstance(draw_circuit, bool):
         raise QuantestPyError("draw_circuit must be bool type.")
 
@@ -200,7 +197,7 @@ def assert_unary_iteration(
                 raise QuantestPyAssertionError(err_msg)
 
         # check ancilla == 0
-        if check_ancilla_is_uncomputed:
+        if len(ancilla_reg) > 0:
             return_from_assert_ancilla_reset = _assert_ancilla_reset(
                 pc_org,
                 index_reg,

--- a/quantestpy/assertion/assert_unary_iteration.py
+++ b/quantestpy/assertion/assert_unary_iteration.py
@@ -1,0 +1,228 @@
+import copy
+import re
+import sys
+from typing import Union
+
+import numpy as np
+
+from quantestpy.assertion.assert_circuit_equivalent_to_output_qubit_state \
+    import PauliCircuitDrawerColorErrorQubit
+from quantestpy.converter.converter_to_quantestpy_circuit import \
+    cvt_input_circuit_to_quantestpy_circuit
+from quantestpy.exceptions import QuantestPyAssertionError, QuantestPyError
+from quantestpy.simulator.pauli_circuit import (
+    PauliCircuit, cvt_quantestpy_circuit_to_pauli_circuit)
+
+
+def _is_a_in_b(a: list, b: list) -> bool:
+    for i in a:
+        if i in b:
+            return True
+    return False
+
+
+def _assert_internal_replacing_gates_in_system_reg_with_x_gates(
+        pauli_circuit_org: PauliCircuit,
+        index_reg: list,
+        system_reg: list,
+        in_bitstring: str,
+        out_bitstring: str) -> Union[str, None]:
+    # define the circuit object
+    pc = copy.deepcopy(pauli_circuit_org)
+    pc.set_qubit_value(index_reg, [int(i) for i in in_bitstring])
+
+    # replace gates in system register to x-gates
+    for gate_id, gate in enumerate(pc.gates):
+        tgt_qubit_idx = gate["target_qubit"]
+        if _is_a_in_b(a=tgt_qubit_idx, b=system_reg):
+            pc.gates[gate_id]["name"] = "x"
+
+    # execute all gates
+    pc._execute_all_gates()
+
+    # get output
+    out_bitstring_actual = \
+        "".join([str(i) for i in pc.qubit_value[system_reg]])
+
+    # check out_bitstring
+    if out_bitstring_actual != out_bitstring:
+        return out_bitstring_actual
+    else:
+        return None
+
+
+def _assert_ancilla_reset(pauli_circuit_org: PauliCircuit,
+                          index_reg: list,
+                          ancilla_reg: list,
+                          in_bitstring: str) -> Union[list, None]:
+    # define the circuit object
+    pc = copy.deepcopy(pauli_circuit_org)
+    pc.set_qubit_value(index_reg, [int(i) for i in in_bitstring])
+
+    # execute all gates
+    pc._execute_all_gates()
+
+    # check ancilla reg
+    if not np.all(pc.qubit_value[ancilla_reg] == 0):
+        ancilla_err_reg = np.array(ancilla_reg)[
+            pc.qubit_value[ancilla_reg] != 0].tolist()
+        return ancilla_err_reg
+    else:
+        return None
+
+
+def _draw_circuit(pauli_circuit_org: PauliCircuit,
+                  index_reg: list,
+                  system_reg: list,
+                  ancilla_reg: list,
+                  in_bitstring: str,
+                  err_msg: str,
+                  val_err_reg: list,
+                  replace_gate: bool = True) -> None:
+    # define the circuit
+    pc = copy.deepcopy(pauli_circuit_org)
+    pc.set_qubit_value(index_reg, [int(i) for i in in_bitstring])
+
+    # replace gates in system register to x-gates
+    if replace_gate:
+        for gate_id, gate in enumerate(pc.gates):
+            tgt_qubit_idx = gate["target_qubit"]
+            if _is_a_in_b(a=tgt_qubit_idx, b=system_reg):
+                pc.gates[gate_id]["name"] = "x"
+
+    # create an instance of PauliCircuitDrawerColorErrorQubit
+    gc = PauliCircuitDrawerColorErrorQubit(
+        circuit=pc,
+        output_reg=system_reg if len(system_reg) > 0 else ancilla_reg,
+        val_err_reg=val_err_reg,
+        color_phase=False,
+        phase_err_reg=[]
+    )
+    gc.set_name_to_reg({"in": index_reg})
+    if len(system_reg) > 0:
+        gc.set_name_to_output_reg({"system": system_reg})
+    elif len(ancilla_reg) > 0:
+        gc.set_name_to_output_reg({"ancilla": ancilla_reg})
+    else:
+        raise QuantestPyError("Unexpected error. Please report.")
+    gc.draw_circuit()
+    length = len(list(gc.line_id_to_text_whole.values()))
+    fig = gc.create_single_string()
+
+    # show figure
+    err_msg_len = len(re.findall(r"\n{1}", err_msg)) + 1
+    print(err_msg)
+    print(fig)
+    input("press enter")
+    for _ in range(err_msg_len+length+1):
+        sys.stdout.write("\033[1A\033[2K")
+    del pc, gc
+    return
+
+
+def assert_unary_iteration(
+        circuit,
+        index_reg: list,
+        system_reg: list,
+        input_to_output: dict,
+        ancilla_reg: list = [],
+        check_ancilla_is_uncomputed: bool = False,
+        draw_circuit: bool = False):
+    """
+    e.g.
+    input_to_output = {
+        "1000": "10000000",
+        "1001": "11000000"
+    }
+    """
+    quantestpy_circuit = cvt_input_circuit_to_quantestpy_circuit(circuit)
+    pc_org = cvt_quantestpy_circuit_to_pauli_circuit(quantestpy_circuit)
+
+    # check inputs
+    pc_org._assert_is_correct_reg(index_reg)
+    pc_org._assert_is_correct_reg(system_reg)
+    pc_org._assert_is_correct_reg(ancilla_reg)
+    if not isinstance(input_to_output, dict):
+        raise QuantestPyError("input_to_output must be a dict.")
+    if not isinstance(check_ancilla_is_uncomputed, bool):
+        raise QuantestPyError("check_ancilla_is_uncomputed must be bool type.")
+    if not isinstance(draw_circuit, bool):
+        raise QuantestPyError("draw_circuit must be bool type.")
+
+    len_index_reg = len(index_reg)
+    len_system_reg = len(system_reg)
+    for in_bitstring, out_bitstring in input_to_output.items():
+        # check input type
+        if not isinstance(in_bitstring, str):
+            raise QuantestPyError("Input must be a binary bitstring.")
+        if len(in_bitstring) != len_index_reg:
+            raise QuantestPyError("Input bitstring has an invalid length.")
+
+        # check output type
+        if not isinstance(out_bitstring, str):
+            raise QuantestPyError("Output must be a binary bitstring.")
+        if len(out_bitstring) != len_system_reg:
+            raise QuantestPyError("Output bitstring has an invalid length.")
+
+        # check actual == expect
+        return_from_assert_equal = \
+            _assert_internal_replacing_gates_in_system_reg_with_x_gates(
+                pc_org,
+                index_reg,
+                system_reg,
+                in_bitstring,
+                out_bitstring
+            )
+
+        # actual != expect
+        if return_from_assert_equal is not None:
+            out_bitstring_actual = return_from_assert_equal
+            err_msg = f"In bitstring: {in_bitstring}\n" \
+                + f"Out bitstring expect: {out_bitstring}\n" \
+                + f"Out bitstring actual: {out_bitstring_actual}"
+
+            if draw_circuit:
+                val_err_reg = []
+                for i, (j, k) in enumerate(
+                        zip(out_bitstring, out_bitstring_actual)):
+                    if j != k:
+                        val_err_reg.append(system_reg[i])
+
+                _draw_circuit(pauli_circuit_org=pc_org,
+                              index_reg=index_reg,
+                              system_reg=system_reg,
+                              ancilla_reg=[],
+                              in_bitstring=in_bitstring,
+                              err_msg=err_msg,
+                              val_err_reg=val_err_reg,
+                              replace_gate=True)
+            else:
+                raise QuantestPyAssertionError(err_msg)
+
+        # check ancilla == 0
+        if check_ancilla_is_uncomputed:
+            return_from_assert_ancilla_reset = _assert_ancilla_reset(
+                pc_org,
+                index_reg,
+                ancilla_reg,
+                in_bitstring
+            )
+
+            # ancilla != 0
+            if return_from_assert_ancilla_reset is not None:
+                ancilla_err_reg = return_from_assert_ancilla_reset
+                err_msg = f"In bitstring: {in_bitstring}\n" \
+                    + f"Qubits {ancilla_err_reg} in ancilla reg are not" \
+                    + " back to 0 by uncomputation."
+
+                if draw_circuit:
+                    _draw_circuit(pauli_circuit_org=pc_org,
+                                  index_reg=index_reg,
+                                  system_reg=[],
+                                  ancilla_reg=ancilla_reg,
+                                  in_bitstring=in_bitstring,
+                                  err_msg=err_msg,
+                                  val_err_reg=ancilla_err_reg,
+                                  replace_gate=False)
+                else:
+                    raise QuantestPyAssertionError(err_msg)

--- a/quantestpy/assertion/assert_unary_iteration.py
+++ b/quantestpy/assertion/assert_unary_iteration.py
@@ -73,16 +73,12 @@ def _assert_ancilla_reset(pauli_circuit_org: PauliCircuit,
 
 def _draw_circuit(pauli_circuit_org: PauliCircuit,
                   index_reg: list,
-                  system_reg: list,
-                  ancilla_reg: list,
+                  output_reg: list,
+                  output_reg_name: str,
                   in_bitstring: str,
                   err_msg: str,
                   val_err_reg: list,
                   replace_gate: bool = True) -> None:
-    # Check input
-    if len(system_reg) > 0 and len(ancilla_reg) > 0:
-        raise QuantestPyError("Unexpected error. Please report.")
-
     # define the circuit
     pc = copy.deepcopy(pauli_circuit_org)
     pc.set_qubit_value(index_reg, [int(i) for i in in_bitstring])
@@ -91,24 +87,19 @@ def _draw_circuit(pauli_circuit_org: PauliCircuit,
     if replace_gate:
         for gate_id, gate in enumerate(pc.gates):
             tgt_qubit_idx = gate["target_qubit"]
-            if _is_a_in_b(a=tgt_qubit_idx, b=system_reg):
+            if _is_a_in_b(a=tgt_qubit_idx, b=output_reg):
                 pc.gates[gate_id]["name"] = "x"
 
     # create an instance of PauliCircuitDrawerColorErrorQubit
     gc = PauliCircuitDrawerColorErrorQubit(
         circuit=pc,
-        output_reg=system_reg if len(system_reg) > 0 else ancilla_reg,
+        output_reg=output_reg,
         val_err_reg=val_err_reg,
         color_phase=False,
         phase_err_reg=[]
     )
     gc.set_name_to_reg({"in": index_reg})
-    if len(system_reg) > 0:
-        gc.set_name_to_output_reg({"system": system_reg})
-    elif len(ancilla_reg) > 0:
-        gc.set_name_to_output_reg({"ancilla": ancilla_reg})
-    else:
-        raise QuantestPyError("Unexpected error. Please report.")
+    gc.set_name_to_output_reg({output_reg_name: output_reg})
     gc.draw_circuit()
     length = len(list(gc.line_id_to_text_whole.values()))
     fig = gc.create_single_string()
@@ -191,8 +182,8 @@ def assert_unary_iteration(
 
                 _draw_circuit(pauli_circuit_org=pc_org,
                               index_reg=index_reg,
-                              system_reg=system_reg,
-                              ancilla_reg=[],
+                              output_reg=system_reg,
+                              output_reg_name="system",
                               in_bitstring=in_bitstring,
                               err_msg=err_msg,
                               val_err_reg=val_err_reg,
@@ -219,8 +210,8 @@ def assert_unary_iteration(
                 if draw_circuit:
                     _draw_circuit(pauli_circuit_org=pc_org,
                                   index_reg=index_reg,
-                                  system_reg=[],
-                                  ancilla_reg=ancilla_reg,
+                                  output_reg=ancilla_reg,
+                                  output_reg_name="ancilla",
                                   in_bitstring=in_bitstring,
                                   err_msg=err_msg,
                                   val_err_reg=ancilla_err_reg,

--- a/test/assertion/assert_unary_iteration/test_assert_ancilla_reset.py
+++ b/test/assertion/assert_unary_iteration/test_assert_ancilla_reset.py
@@ -1,0 +1,54 @@
+import unittest
+
+from quantestpy.assertion.assert_unary_iteration import _assert_ancilla_reset
+from quantestpy.simulator.pauli_circuit import PauliCircuit
+
+
+class TestAssertInternal(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest \
+        test.assertion.assert_unary_iteration.test_assert_ancilla_reset
+    ..
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.001s
+    OK
+    $
+    """
+
+    def test_return_none(self):
+        pc = PauliCircuit(5)
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        pc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [3],
+                    "control_value": [1]})
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+
+        self.assertIsNone(
+            _assert_ancilla_reset(
+                pauli_circuit_org=pc,
+                index_reg=[0, 1],
+                ancilla_reg=[2],
+                in_bitstring="11"
+            )
+        )
+
+    def test_return_obj(self):
+        pc = PauliCircuit(5)
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        pc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [3],
+                    "control_value": [1]})
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [0, 0]})
+
+        output = _assert_ancilla_reset(
+            pauli_circuit_org=pc,
+            index_reg=[0, 1],
+            ancilla_reg=[2],
+            in_bitstring="11"
+        )
+        self.assertEqual(output, [2])

--- a/test/assertion/assert_unary_iteration/test_assert_equal_qubit_state.py
+++ b/test/assertion/assert_unary_iteration/test_assert_equal_qubit_state.py
@@ -1,17 +1,17 @@
 import unittest
 
 from quantestpy.assertion.assert_unary_iteration import \
-    _assert_internal_replacing_gates_in_system_reg_with_x_gates
+    _assert_equal_qubit_state_replacing_gates_in_sys_reg_with_x_gates
 from quantestpy.simulator.pauli_circuit import PauliCircuit
 
 
-class TestAssertInternal(unittest.TestCase):
+class TestAssertEqualQubitState(unittest.TestCase):
     """
     How to execute this test:
     $ pwd
     {Your directory where you git-cloned quantestpy}/quantestpy
     $ python -m unittest \
-        test.assertion.assert_unary_iteration.test_assert_internal
+        test.assertion.assert_unary_iteration.test_assert_equal_qubit_state
     ..
     ----------------------------------------------------------------------
     Ran 2 tests in 0.001s
@@ -27,7 +27,7 @@ class TestAssertInternal(unittest.TestCase):
                     "control_value": [1, 1]})
 
         self.assertIsNone(
-            _assert_internal_replacing_gates_in_system_reg_with_x_gates(
+            _assert_equal_qubit_state_replacing_gates_in_sys_reg_with_x_gates(
                 pauli_circuit_org=pc,
                 index_reg=[0, 1],
                 system_reg=[2, 3, 4],
@@ -43,11 +43,12 @@ class TestAssertInternal(unittest.TestCase):
         pc.add_gate({"name": "y", "control_qubit": [0, 1], "target_qubit": [3],
                     "control_value": [1, 1]})
 
-        output = _assert_internal_replacing_gates_in_system_reg_with_x_gates(
-            pauli_circuit_org=pc,
-            index_reg=[0, 1],
-            system_reg=[2, 3, 4],
-            in_bitstring="11",
-            out_bitstring="100"
-        )
+        output = \
+            _assert_equal_qubit_state_replacing_gates_in_sys_reg_with_x_gates(
+                pauli_circuit_org=pc,
+                index_reg=[0, 1],
+                system_reg=[2, 3, 4],
+                in_bitstring="11",
+                out_bitstring="100"
+            )
         self.assertEqual(output, "110")

--- a/test/assertion/assert_unary_iteration/test_assert_internal.py
+++ b/test/assertion/assert_unary_iteration/test_assert_internal.py
@@ -1,0 +1,53 @@
+import unittest
+
+from quantestpy.assertion.assert_unary_iteration import \
+    _assert_internal_replacing_gates_in_system_reg_with_x_gates
+from quantestpy.simulator.pauli_circuit import PauliCircuit
+
+
+class TestAssertInternal(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest \
+        test.assertion.assert_unary_iteration.test_assert_internal
+    ..
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.001s
+    OK
+    $
+    """
+
+    def test_return_none(self):
+        pc = PauliCircuit(5)
+        pc.add_gate({"name": "z", "control_qubit": [0], "target_qubit": [2],
+                    "control_value": [1]})
+        pc.add_gate({"name": "y", "control_qubit": [0, 1], "target_qubit": [3],
+                    "control_value": [1, 1]})
+
+        self.assertIsNone(
+            _assert_internal_replacing_gates_in_system_reg_with_x_gates(
+                pauli_circuit_org=pc,
+                index_reg=[0, 1],
+                system_reg=[2, 3, 4],
+                in_bitstring="10",
+                out_bitstring="100"
+            )
+        )
+
+    def test_return_str(self):
+        pc = PauliCircuit(5)
+        pc.add_gate({"name": "z", "control_qubit": [0], "target_qubit": [2],
+                    "control_value": [1]})
+        pc.add_gate({"name": "y", "control_qubit": [0, 1], "target_qubit": [3],
+                    "control_value": [1, 1]})
+
+        output = _assert_internal_replacing_gates_in_system_reg_with_x_gates(
+            pauli_circuit_org=pc,
+            index_reg=[0, 1],
+            system_reg=[2, 3, 4],
+            in_bitstring="11",
+            out_bitstring="100"
+        )
+        self.assertEqual(output, "110")

--- a/test/assertion/assert_unary_iteration/test_assert_unary_iteration.py
+++ b/test/assertion/assert_unary_iteration/test_assert_unary_iteration.py
@@ -14,9 +14,10 @@ class TestAssertUnaryIteration(unittest.TestCase):
     {Your directory where you git-cloned quantestpy}/quantestpy
     $ python -m unittest \
         test.assertion.assert_unary_iteration.test_assert_unary_iteration
-    .......
+    .........
     ----------------------------------------------------------------------
-    Ran 7 tests in 0.010s
+    Ran 9 tests in 0.021s
+
     OK
     $
     """

--- a/test/assertion/assert_unary_iteration/test_assert_unary_iteration.py
+++ b/test/assertion/assert_unary_iteration/test_assert_unary_iteration.py
@@ -91,14 +91,14 @@ class TestAssertUnaryIteration(unittest.TestCase):
             assert_unary_iteration(
                 circuit=qc,
                 index_reg=[0, 1],
-                ancilla_reg=[2],
                 system_reg=[3, 4],
                 input_to_output={
                     "00": "00",
                     "01": "00",
                     "10": "00",
                     "11": "11"
-                }
+                },
+                ancilla_reg=[2]
             )
         self.assertEqual(cm.exception.args[0], expected_error_msg)
 
@@ -207,13 +207,13 @@ class TestDrawCircuitOption(unittest.TestCase):
                 circuit=qc,
                 index_reg=[0, 1],
                 system_reg=[3, 4],
-                ancilla_reg=[2],
                 input_to_output={
                     "00": "00",
                     "01": "00",
                     "10": "00",
                     "11": "10"  # error
                 },
+                ancilla_reg=[2],
                 draw_circuit=True
             )
         )
@@ -242,7 +242,6 @@ class TestDrawCircuitOption(unittest.TestCase):
             assert_unary_iteration(
                 circuit=qc,
                 index_reg=[0, 1],
-                ancilla_reg=[2],
                 system_reg=[3, 4],
                 input_to_output={
                     "00": "00",
@@ -250,6 +249,7 @@ class TestDrawCircuitOption(unittest.TestCase):
                     "10": "00",
                     "11": "11"
                 },
+                ancilla_reg=[2],
                 draw_circuit=True
             )
         )

--- a/test/assertion/assert_unary_iteration/test_assert_unary_iteration.py
+++ b/test/assertion/assert_unary_iteration/test_assert_unary_iteration.py
@@ -1,0 +1,262 @@
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from quantestpy import QuantestPyCircuit, assert_unary_iteration
+from quantestpy.exceptions import QuantestPyAssertionError, QuantestPyError
+
+
+class TestAssertUnaryIteration(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest \
+        test.assertion.assert_unary_iteration.test_assert_unary_iteration
+    .......
+    ----------------------------------------------------------------------
+    Ran 7 tests in 0.010s
+    OK
+    $
+    """
+
+    def test_return_none(self,):
+
+        qc = QuantestPyCircuit(5)
+        qc.add_gate({"name": "z", "control_qubit": [0], "target_qubit": [2],
+                    "control_value": [1]})
+        qc.add_gate({"name": "y", "control_qubit": [0, 1], "target_qubit": [3],
+                    "control_value": [1, 1]})
+
+        self.assertIsNone(
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1],
+                system_reg=[2, 3, 4],
+                input_to_output={
+                    "00": "000",
+                    "01": "000",
+                    "10": "100",
+                    "11": "110"
+                }
+            )
+        )
+
+    def test_return_assert_error(self,):
+
+        qc = QuantestPyCircuit(5)
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        qc.add_gate({"name": "z", "control_qubit": [2], "target_qubit": [3],
+                    "control_value": [1]})
+        qc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [4],
+                    "control_value": [1]})
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+
+        expected_error_msg = "In bitstring: 10\n" \
+            + "Out bitstring expect: 10\n" \
+            + "Out bitstring actual: 00"
+        with self.assertRaises(QuantestPyAssertionError) as cm:
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1],
+                system_reg=[3, 4],
+                input_to_output={
+                    "00": "00",
+                    "01": "00",
+                    "10": "10",
+                    "11": "11"
+                }
+            )
+        self.assertEqual(cm.exception.args[0], expected_error_msg)
+
+    def test_return_ancilla_error(self,):
+
+        qc = QuantestPyCircuit(5)
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        qc.add_gate({"name": "z", "control_qubit": [2], "target_qubit": [3],
+                    "control_value": [1]})
+        qc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [4],
+                    "control_value": [1]})
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 0]})
+
+        expected_error_msg = "In bitstring: 10\n" \
+            + "Qubits [2] in ancilla reg are not back to 0 by uncomputation."
+        with self.assertRaises(QuantestPyAssertionError) as cm:
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1],
+                ancilla_reg=[2],
+                system_reg=[3, 4],
+                input_to_output={
+                    "00": "00",
+                    "01": "00",
+                    "10": "00",
+                    "11": "11"
+                },
+                check_ancilla_is_uncomputed=True
+            )
+        self.assertEqual(cm.exception.args[0], expected_error_msg)
+
+
+class TestInput(unittest.TestCase):
+
+    def test_raise_from_invalid_input_type(self,):
+        qc = QuantestPyCircuit(4)
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        qc.add_gate({"name": "z", "control_qubit": [], "target_qubit": [2],
+                    "control_value": []})
+
+        expected_error_msg = "Input must be a binary bitstring."
+
+        with self.assertRaises(QuantestPyError) as cm:
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1],
+                system_reg=[2, 3],
+                input_to_output={11: "00"}
+            )
+
+        self.assertEqual(cm.exception.args[0], expected_error_msg)
+
+    def test_raise_from_invalid_input_length(self,):
+        qc = QuantestPyCircuit(4)
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+
+        expected_error_msg = "Input bitstring has an invalid length."
+
+        with self.assertRaises(QuantestPyError) as cm:
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1, 3],
+                system_reg=[2],
+                input_to_output={"11": "0"}
+            )
+
+        self.assertEqual(cm.exception.args[0], expected_error_msg)
+
+    def test_raise_from_invalid_output_type(self,):
+        qc = QuantestPyCircuit(5)
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+
+        expected_error_msg = "Output must be a binary bitstring."
+
+        with self.assertRaises(QuantestPyError) as cm:
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1],
+                system_reg=[2, 3, 4],
+                input_to_output={
+                    "11": ("010", [0, 0, 0.5])
+                }
+            )
+
+        self.assertEqual(cm.exception.args[0], expected_error_msg)
+
+    def test_raise_from_invalid_output_bitstring_length(self,):
+        qc = QuantestPyCircuit(5)
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        qc.add_gate({"name": "x", "control_qubit": [], "target_qubit": [3],
+                    "control_value": []})
+
+        expected_error_msg = "Output bitstring has an invalid length."
+
+        with self.assertRaises(QuantestPyError) as cm:
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1],
+                system_reg=[2, 4],
+                input_to_output={"11": "010"}
+            )
+
+        self.assertEqual(cm.exception.args[0], expected_error_msg)
+
+
+class TestDrawCircuitOption(unittest.TestCase):
+
+    def setUp(self):
+        self.capture = StringIO()
+        sys.stdout = self.capture
+
+    def tearDown(self):
+        sys.stdout = sys.__stdout__
+
+    @ patch("builtins.input", return_value="")
+    def test_assert_error(self, input):
+
+        qc = QuantestPyCircuit(5)
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        qc.add_gate({"name": "z", "control_qubit": [2], "target_qubit": [3],
+                    "control_value": [1]})
+        qc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [4],
+                    "control_value": [1]})
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+
+        self.assertIsNone(
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1],
+                system_reg=[3, 4],
+                ancilla_reg=[2],
+                input_to_output={
+                    "00": "00",
+                    "01": "00",
+                    "10": "00",
+                    "11": "10"  # error
+                },
+                draw_circuit=True
+            )
+        )
+
+        stdout = self.capture.getvalue()
+        self.assertIsInstance(stdout, str)
+
+        err_msg = "In bitstring: 11\nOut bitstring expect: 10\n" \
+                  + "Out bitstring actual: 11"
+        self.assertTrue(err_msg in stdout)
+
+    @ patch("builtins.input", return_value="")
+    def test_ancilla_error(self, input):
+
+        qc = QuantestPyCircuit(5)
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        qc.add_gate({"name": "z", "control_qubit": [2], "target_qubit": [3],
+                    "control_value": [1]})
+        qc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [4],
+                    "control_value": [1]})
+        qc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [0, 0]})
+
+        self.assertIsNone(
+            assert_unary_iteration(
+                circuit=qc,
+                index_reg=[0, 1],
+                ancilla_reg=[2],
+                system_reg=[3, 4],
+                input_to_output={
+                    "00": "00",
+                    "01": "00",
+                    "10": "00",
+                    "11": "11"
+                },
+                draw_circuit=True,
+                check_ancilla_is_uncomputed=True
+            )
+        )
+
+        stdout = self.capture.getvalue()
+        self.assertIsInstance(stdout, str)
+
+        err_msg = "In bitstring: 11\nQubits [2] in ancilla reg"
+        self.assertTrue(err_msg in stdout)

--- a/test/assertion/assert_unary_iteration/test_assert_unary_iteration.py
+++ b/test/assertion/assert_unary_iteration/test_assert_unary_iteration.py
@@ -97,8 +97,7 @@ class TestAssertUnaryIteration(unittest.TestCase):
                     "01": "00",
                     "10": "00",
                     "11": "11"
-                },
-                check_ancilla_is_uncomputed=True
+                }
             )
         self.assertEqual(cm.exception.args[0], expected_error_msg)
 
@@ -250,8 +249,7 @@ class TestDrawCircuitOption(unittest.TestCase):
                     "10": "00",
                     "11": "11"
                 },
-                draw_circuit=True,
-                check_ancilla_is_uncomputed=True
+                draw_circuit=True
             )
         )
 

--- a/test/assertion/assert_unary_iteration/test_draw_circuit.py
+++ b/test/assertion/assert_unary_iteration/test_draw_circuit.py
@@ -1,0 +1,79 @@
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from quantestpy import PauliCircuit
+from quantestpy.assertion.assert_unary_iteration import _draw_circuit
+
+
+class TestDrawCircuit(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest \
+        test.assertion.assert_unary_iteration.test_draw_circuit
+    ..
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.005s
+
+    OK
+    $
+    """
+
+    def setUp(self):
+        self.capture = StringIO()
+        sys.stdout = self.capture
+
+    def tearDown(self):
+        sys.stdout = sys.__stdout__
+
+    @patch("builtins.input", return_value="")
+    def test_color_system_reg(self, input):
+        pc = PauliCircuit(5)
+        pc.add_gate({"name": "z", "control_qubit": [0], "target_qubit": [2],
+                    "control_value": [1]})
+        pc.add_gate({"name": "y", "control_qubit": [0, 1], "target_qubit": [3],
+                    "control_value": [1, 1]})
+
+        _draw_circuit(
+            pauli_circuit_org=pc,
+            index_reg=[0, 1],
+            system_reg=[2, 3, 4],
+            ancilla_reg=[],
+            in_bitstring="11",
+            err_msg="This is an err msg.",
+            val_err_reg=[3],
+            replace_gate=True
+        )
+
+        stdout = self.capture.getvalue()
+        self.assertIsInstance(stdout, str)
+        for s in ["This is an err msg.", "[X]"]:
+            self.assertTrue(s in stdout)
+
+    @patch("builtins.input", return_value="")
+    def test_color_ancilla_reg(self, input):
+        pc = PauliCircuit(5)
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        pc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [3],
+                    "control_value": [1]})
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [0, 0]})
+
+        _draw_circuit(
+            pauli_circuit_org=pc,
+            index_reg=[0, 1],
+            system_reg=[],
+            ancilla_reg=[2],
+            in_bitstring="11",
+            err_msg="This is an err msg.",
+            val_err_reg=[2]
+        )
+
+        stdout = self.capture.getvalue()
+        self.assertIsInstance(stdout, str)
+        for s in ["This is an err msg.", "[Y]"]:
+            self.assertTrue(s in stdout)

--- a/test/assertion/assert_unary_iteration/test_draw_circuit.py
+++ b/test/assertion/assert_unary_iteration/test_draw_circuit.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from quantestpy import PauliCircuit
 from quantestpy.assertion.assert_unary_iteration import _draw_circuit
+from quantestpy.exceptions import QuantestPyError
 
 
 class TestDrawCircuit(unittest.TestCase):
@@ -14,9 +15,9 @@ class TestDrawCircuit(unittest.TestCase):
     {Your directory where you git-cloned quantestpy}/quantestpy
     $ python -m unittest \
         test.assertion.assert_unary_iteration.test_draw_circuit
-    ..
+    ...
     ----------------------------------------------------------------------
-    Ran 2 tests in 0.005s
+    Ran 3 tests in 0.008s
 
     OK
     $
@@ -77,3 +78,30 @@ class TestDrawCircuit(unittest.TestCase):
         self.assertIsInstance(stdout, str)
         for s in ["This is an err msg.", "[Y]"]:
             self.assertTrue(s in stdout)
+
+
+class TestInput(unittest.TestCase):
+
+    def test_raise_from_invalid_input_set(self,):
+        pc = PauliCircuit(5)
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+        pc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [3],
+                    "control_value": [1]})
+        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
+                    "control_value": [1, 1]})
+
+        expected_error_msg = "Unexpected error. Please report."
+
+        with self.assertRaises(QuantestPyError) as cm:
+            _draw_circuit(
+                pauli_circuit_org=pc,
+                index_reg=[0, 1],
+                system_reg=[3, 4],
+                ancilla_reg=[2],
+                in_bitstring="11",
+                err_msg="This is an err msg.",
+                val_err_reg=[2, 3]
+            )
+
+        self.assertEqual(cm.exception.args[0], expected_error_msg)

--- a/test/assertion/assert_unary_iteration/test_draw_circuit.py
+++ b/test/assertion/assert_unary_iteration/test_draw_circuit.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 from quantestpy import PauliCircuit
 from quantestpy.assertion.assert_unary_iteration import _draw_circuit
-from quantestpy.exceptions import QuantestPyError
 
 
 class TestDrawCircuit(unittest.TestCase):
@@ -41,8 +40,8 @@ class TestDrawCircuit(unittest.TestCase):
         _draw_circuit(
             pauli_circuit_org=pc,
             index_reg=[0, 1],
-            system_reg=[2, 3, 4],
-            ancilla_reg=[],
+            output_reg=[2, 3, 4],
+            output_reg_name="system",
             in_bitstring="11",
             err_msg="This is an err msg.",
             val_err_reg=[3],
@@ -67,8 +66,8 @@ class TestDrawCircuit(unittest.TestCase):
         _draw_circuit(
             pauli_circuit_org=pc,
             index_reg=[0, 1],
-            system_reg=[],
-            ancilla_reg=[2],
+            output_reg=[2],
+            output_reg_name="ancilla",
             in_bitstring="11",
             err_msg="This is an err msg.",
             val_err_reg=[2]
@@ -78,30 +77,3 @@ class TestDrawCircuit(unittest.TestCase):
         self.assertIsInstance(stdout, str)
         for s in ["This is an err msg.", "[Y]"]:
             self.assertTrue(s in stdout)
-
-
-class TestInput(unittest.TestCase):
-
-    def test_raise_from_invalid_input_set(self,):
-        pc = PauliCircuit(5)
-        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
-                    "control_value": [1, 1]})
-        pc.add_gate({"name": "y", "control_qubit": [2], "target_qubit": [3],
-                    "control_value": [1]})
-        pc.add_gate({"name": "x", "control_qubit": [0, 1], "target_qubit": [2],
-                    "control_value": [1, 1]})
-
-        expected_error_msg = "Unexpected error. Please report."
-
-        with self.assertRaises(QuantestPyError) as cm:
-            _draw_circuit(
-                pauli_circuit_org=pc,
-                index_reg=[0, 1],
-                system_reg=[3, 4],
-                ancilla_reg=[2],
-                in_bitstring="11",
-                err_msg="This is an err msg.",
-                val_err_reg=[2, 3]
-            )
-
-        self.assertEqual(cm.exception.args[0], expected_error_msg)

--- a/test/assertion/assert_unary_iteration/test_is_a_in_b.py
+++ b/test/assertion/assert_unary_iteration/test_is_a_in_b.py
@@ -1,0 +1,27 @@
+import unittest
+
+from quantestpy.assertion.assert_unary_iteration import _is_a_in_b
+
+
+class TestIsAinB(unittest.TestCase):
+    """
+    How to execute this test:
+    $ pwd
+    {Your directory where you git-cloned quantestpy}/quantestpy
+    $ python -m unittest test.assertion.assert_unary_iteration.test_is_a_in_b
+    ..
+    ----------------------------------------------------------------------
+    Ran 2 tests in 0.000s
+    OK
+    $
+    """
+
+    def test_return_true(self):
+        a = [1, 2, 3, 4]
+        b = [4, 1, 5, 6, "i"]
+        self.assertTrue(_is_a_in_b(a, b))
+
+    def test_return_false(self):
+        a = [1, 2, 3, 4, "j"]
+        b = [10, 9, 5, 6, "i"]
+        self.assertFalse(_is_a_in_b(a, b))


### PR DESCRIPTION
## Summary
This assert method is designed for testing unary iteration circuits (though it might have other use cases, too). The method raises a QuantestPyAssertionError if qubit values of a system register in final state are different from user's expectation. The gates in the system register are replaced internally with X-gates. This makes it easier for users to define the expected qubit values of the system register. 

Optionally, the method prints out the circuit figure instead of raising a QuantestPyAssertionError when the assertion error occurred.

## Example
```py
from quantestpy import QuantestPyCircuit, assert_unary_iteration

qc = QuantestPyCircuit(20)
qc.add_gate({"name": "x", "target_qubit": [2], "control_qubit": [0, 1],
             "control_value": [1, 0]})
qc.add_gate({"name": "x", "target_qubit": [4], "control_qubit": [2, 3],
             "control_value": [1, 0]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [4, 5],
             "control_value": [1, 0]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 0]})
# X_0
qc.add_gate({"name": "y", "target_qubit": [9], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6],
             "control_value": [1]})
# X_1
qc.add_gate({"name": "y", "target_qubit": [10], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [4],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 0]})
# X_2
qc.add_gate({"name": "y", "target_qubit": [11], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6],
             "control_value": [1]})
# X_3
qc.add_gate({"name": "y", "target_qubit": [12], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [4, 5],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [4], "control_qubit": [2],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [4, 5],
             "control_value": [1, 0]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 0]})
# X_4
qc.add_gate({"name": "y", "target_qubit": [13], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6],
             "control_value": [1]})
# X_5
qc.add_gate({"name": "y", "target_qubit": [14], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [4],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 0]})
# X_6
qc.add_gate({"name": "y", "target_qubit": [15], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6],
             "control_value": [1]})
# X_7
qc.add_gate({"name": "y", "target_qubit": [16], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [4, 5],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [4], "control_qubit": [2, 3],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [2], "control_qubit": [0],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [2, 5],
             "control_value": [1, 0]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 0]})
# X_8
qc.add_gate({"name": "y", "target_qubit": [17], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6],
             "control_value": [1]})
# X_9
qc.add_gate({"name": "y", "target_qubit": [18], "control_qubit": [8],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [8], "control_qubit": [6, 7],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [3],
             "control_value": [1]})
# X_10
qc.add_gate({"name": "y", "target_qubit": [19], "control_qubit": [6],
             "control_value": [1]})
qc.add_gate({"name": "x", "target_qubit": [6], "control_qubit": [2, 5],
             "control_value": [1, 1]})
qc.add_gate({"name": "x", "target_qubit": [2], "control_qubit": [0, 1],
             "control_value": [1, 1]})
```
The above circuit is constructed with an error intentionally.
Use the assert method to check the consistency:
```py
assert_unary_iteration(
    circuit=qc,
    index_reg=[0, 1, 3, 5, 7],
    system_reg=[9, 10, 11, 12, 13, 14, 15,
                16, 17, 18, 19],
    input_to_output={
        "10000": "10000000000",
        "10001": "01000000000",
        "10010": "00100000000",
        "10011": "00010000000",
        "10100": "00001000000",
        "10101": "00000100000",
        "10110": "00000010000",
        "10111": "00000001000",
        "11000": "00000000100",
        "11001": "00000000010",
        "11010": "00000000001"
    }
)
---------------------------------------------------------------------------
QuantestPyAssertionError                  Traceback (most recent call last)
...
QuantestPyAssertionError: In bitstring: 10100
Out bitstring expect: 00001000000
Out bitstring actual: 00001000001
```
Using the draw_circuit option:
```py
assert_unary_iteration(
    circuit=qc,
    index_reg=[0, 1, 3, 5, 7],
    system_reg=[9, 10, 11, 12, 13, 14, 15,
                16, 17, 18, 19],
    input_to_output={
        "10000": "10000000000",
        "10001": "01000000000",
        "10010": "00100000000",
        "10011": "00010000000",
        "10100": "00001000000",
        "10101": "00000100000",
        "10110": "00000010000",
        "10111": "00000001000",
        "11000": "00000000100",
        "11001": "00000000010",
        "11010": "00000000001"
    },
    draw_circuit=True
)
```
![image](https://user-images.githubusercontent.com/47435718/214836208-8dd36cca-3096-44a2-aee4-7efc708028c8.png)
where the error qubit states are highlighted by the red color.
