### PR TITLE
Prepare for using PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,42 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ QuantestPy is an unit testing framework for quantum computing programs.
 We encourage installing QuantestPy via the pip tool(a python package manager).
 The following command installs the core QuantestPy component.
 ```bash
-pip install git+https://github.com/QuantestPy/quantestpy.git
+pip install quantestpy
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["wheel", "setuptools"]
+requires = ["wheel", "setuptools", "setuptools_scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "quantestpy"
-version = "0.1.0"
 license = { text = "Apache 2.0"}
 description = "Software for testing quantum computing programs."
 authors = [{name="Quantestpy Development Team"}]
@@ -12,6 +11,8 @@ requires-python = ">=3.7"
 dependencies = [
   "numpy == 1.*"
 ]
+dynamic = ["version"]
+readme = "README.md"
 
 [project.urls]
 homepage ="https://github.com/QuantestPy/quantestpy"
@@ -30,6 +31,15 @@ qiskit = [
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
+packages = ["quantestpy"]
+
+[tool.setuptools.dynamic]
+version = {attr = "quantestpy._version.__version__"}
+
+[tool.setuptools_scm]
+write_to = "quantestpy/_version.py"
+version_scheme = "release-branch-semver"
+local_scheme = "no-local-version"
 
 [tool.flake8]
 per-file-ignores = "__init__.py:F401"

--- a/quantestpy/__init__.py
+++ b/quantestpy/__init__.py
@@ -23,3 +23,5 @@ from .assertion.assert_equivalent_state_vectors import \
 from .assertion.assert_unitary_operator import assert_unitary_operator
 from .assertion.assert_equivalent_operators import \
     assert_equivalent_operators
+
+from ._version import __version__, __version_tuple__


### PR DESCRIPTION
This PR is to prepare for uploading the package on PyPI.
With this update, [create a new relaese] will trigger a github actions and automatically build and upload the package on PyPI.
This enables users to install via a simpler command `$ pip install quantestpy`
